### PR TITLE
[FEAT]: LocationTrackingManager 추가

### DIFF
--- a/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
+++ b/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		6906BA9F2AD8E8570088FE6E /* MemoListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906BA9E2AD8E8570088FE6E /* MemoListViewController.swift */; };
 		6906BAA12AD91DBC0088FE6E /* MainPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906BAA02AD91DBC0088FE6E /* MainPageView.swift */; };
 		6906BAA32ADD06860088FE6E /* MemoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906BAA22ADD06860088FE6E /* MemoListView.swift */; };
+		69EBADB42ADF75010009CB21 /* LocationTrackingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69EBADB32ADF75010009CB21 /* LocationTrackingManager.swift */; };
 		C735C0442AD8E15A00AA7663 /* NotifyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C735C0432AD8E15A00AA7663 /* NotifyPageViewController.swift */; };
 		C735C0462AD8E16D00AA7663 /* AddNotifyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C735C0452AD8E16D00AA7663 /* AddNotifyPageViewController.swift */; };
 		C735C05F2AD9466C00AA7663 /* CalendarPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C735C05E2AD9466C00AA7663 /* CalendarPageView.swift */; };
@@ -162,6 +163,7 @@
 		6906BA9E2AD8E8570088FE6E /* MemoListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoListViewController.swift; sourceTree = "<group>"; };
 		6906BAA02AD91DBC0088FE6E /* MainPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageView.swift; sourceTree = "<group>"; };
 		6906BAA22ADD06860088FE6E /* MemoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoListView.swift; sourceTree = "<group>"; };
+		69EBADB32ADF75010009CB21 /* LocationTrackingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationTrackingManager.swift; sourceTree = "<group>"; };
 		C735C0432AD8E15A00AA7663 /* NotifyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifyPageViewController.swift; sourceTree = "<group>"; };
 		C735C0452AD8E16D00AA7663 /* AddNotifyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddNotifyPageViewController.swift; sourceTree = "<group>"; };
 		C735C05E2AD9466C00AA7663 /* CalendarPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPageView.swift; sourceTree = "<group>"; };
@@ -412,6 +414,7 @@
 				30445E932ADF0958000D26A4 /* CoreDataManager.swift */,
 				30445EB92ADF1C80000D26A4 /* NetworkDataManager.swift */,
 				085A52BD2ADEADD20041918D /* LoginManager.swift */,
+				69EBADB32ADF75010009CB21 /* LocationTrackingManager.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -629,6 +632,7 @@
 				30445EB72ADF12B4000D26A4 /* FolderModel+CoreDataClass.swift in Sources */,
 				08749B182ADBEE8D00822AE7 /* NotifySettingItemView.swift in Sources */,
 				6906BA9F2AD8E8570088FE6E /* MemoListViewController.swift in Sources */,
+				69EBADB42ADF75010009CB21 /* LocationTrackingManager.swift in Sources */,
 				30E7984B2AD7E20100903272 /* ThemeColorViewController.swift in Sources */,
 				083C985F2AD8D7AC006895D2 /* Observable.swift in Sources */,
 				08A4F88E2AD821A80092C6EF /* MemoOptionCollectionViewCell.swift in Sources */,
@@ -794,8 +798,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Q5P3S25TZQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FinalTodo/Resource/Info.plist;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "GPS 확인";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "GPS 확인";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -821,8 +828,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Q5P3S25TZQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FinalTodo/Resource/Info.plist;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "GPS 확인";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "GPS 확인";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/FinalTodo/FinalTodo/Helper/LocationTrackingManager.swift
+++ b/FinalTodo/FinalTodo/Helper/LocationTrackingManager.swift
@@ -1,0 +1,89 @@
+//
+//  locationManager.swift
+//  FinalTodo
+//
+//  Created by Jongbum Lee on 2023/10/18.
+//
+
+import Foundation
+import CoreLocation
+import UIKit
+
+class LocationTrackingManager: NSObject, CLLocationManagerDelegate {
+    
+    static let shared = LocationTrackingManager()
+    private var locationManager = CLLocationManager()
+    private var locationUpdateTimer: Timer?
+    
+    private override init() {
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        locationManager.allowsBackgroundLocationUpdates = true
+        locationManager.pausesLocationUpdatesAutomatically = false
+    }
+    
+    func startTracking() {
+        let authStatus = locationManager.authorizationStatus
+        switch authStatus {
+        case .notDetermined:
+            locationManager.allowsBackgroundLocationUpdates = true
+            locationManager.requestAlwaysAuthorization()
+        case .authorizedAlways:
+            scheduleLocationUpdates()
+        default:
+            break
+        }
+    }
+    
+    func stopTracking() {
+        locationUpdateTimer?.invalidate()
+        locationManager.stopUpdatingLocation()
+    }
+    
+    private func scheduleLocationUpdates() {
+        locationUpdateTimer?.invalidate()
+        locationUpdateTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            self?.locationManager.startUpdatingLocation()
+        }
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        if let location = locations.last {
+            print("Latitude: \(location.coordinate.latitude), Longitude: \(location.coordinate.longitude)")
+            locationManager.stopUpdatingLocation()
+        }
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("Error: \(error)")
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        switch status {
+        case .restricted, .denied, .authorizedWhenInUse:
+            changeLocationPermission()
+        case .authorizedAlways:
+            startTracking()
+        default:
+            break
+        }
+    }
+    
+    func changeLocationPermission() {
+        let alertController = UIAlertController(title: "위치 권한 필요", message: "앱의 기능을 완전히 활용하려면 '항상 허용' 권한이 필요합니다. 설정으로 이동하시겠습니까?", preferredStyle: .alert)
+        let settingsAction = UIAlertAction(title: "설정으로 이동", style: .default) { (_) in
+            if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(settingsURL, options: [:], completionHandler: nil)
+            }
+        }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+        alertController.addAction(settingsAction)
+        alertController.addAction(cancelAction)
+        
+        if let topController = UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.rootViewController {
+            topController.present(alertController, animated: true, completion: nil)
+        }
+    }
+}
+

--- a/FinalTodo/FinalTodo/Resource/Info.plist
+++ b/FinalTodo/FinalTodo/Resource/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>체크인 기능을 사용하기 위해서 위치정보 권한이 필요합니다.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>체크인 기능을 사용하기 위해서 위치정보 권한이 필요합니다.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>체크인 기능을 사용하기 위해서 위치정보 권한이 필요합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -19,5 +25,9 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 </dict>
 </plist>

--- a/FinalTodo/FinalTodo/Scenes/MainPageScene/MainPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/MainPageScene/MainPageViewController.swift
@@ -11,6 +11,7 @@ import SnapKit
 class MainPageViewController: UIViewController {
     
     var items = [Any]()
+    let locationManager = LocationTrackingManager.shared
     
     var mainView: MainPageView {
         return view as! MainPageView
@@ -25,6 +26,7 @@ class MainPageViewController: UIViewController {
         
         setupUI()
         setupDelegates()
+        locationManager.startTracking()
     }
     
     private func setupUI() {


### PR DESCRIPTION
1. LocationTrackingManager 파일 추가
 - 싱글톤 클래스로 구현
 - 첫 권한 요청 후 '한 번 허용'이나 '허용안함' 클릭 시 재설정을 유도를 위한 설정탭 이동 추가
 - 백그라운드에서 사용자 위치 변동 시 위치정보 접근 '항상 허용'을 위한 설정 탭 이동 기능 추가
 - 접근 허용 시 00초 마다 위치 정보 갱신 기능 추가
2. info.plist 위치정보 접근허용 요청 문구 추가
3. MainPage LocationTrackingManer 추가