### PR TITLE
FEAT: 화면 잠금 기능 구현

### DIFF
--- a/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
+++ b/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		038847D02AD7EF800083C420 /* PwFindViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038847CF2AD7EF800083C420 /* PwFindViewController.swift */; };
 		039B82BB2ADFDEAC00D3A73C /* PwFindPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037668AE2ADD101A008BED0A /* PwFindPageViewController.swift */; };
 		081383912AE004620055FDA2 /* LockScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081383902AE004620055FDA2 /* LockScreenViewController.swift */; };
+		081383952AE008810055FDA2 /* LockScreenNumCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081383942AE008810055FDA2 /* LockScreenNumCollectionViewCell.swift */; };
 		083C985D2AD8D728006895D2 /* Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083C985C2AD8D728006895D2 /* Protocol.swift */; };
 		083C985F2AD8D7AC006895D2 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083C985E2AD8D7AC006895D2 /* Observable.swift */; };
 		083C98622AD8D88E006895D2 /* MemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083C98612AD8D88E006895D2 /* MemoViewModel.swift */; };
@@ -113,6 +114,7 @@
 		037668B42ADE5CEA008BED0A /* commandLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = commandLabelView.swift; sourceTree = "<group>"; };
 		038847CF2AD7EF800083C420 /* PwFindViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PwFindViewController.swift; sourceTree = "<group>"; };
 		081383902AE004620055FDA2 /* LockScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenViewController.swift; sourceTree = "<group>"; };
+		081383942AE008810055FDA2 /* LockScreenNumCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenNumCollectionViewCell.swift; sourceTree = "<group>"; };
 		083C985C2AD8D728006895D2 /* Protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocol.swift; sourceTree = "<group>"; };
 		083C985E2AD8D7AC006895D2 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		083C98612AD8D88E006895D2 /* MemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoViewModel.swift; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 			isa = PBXGroup;
 			children = (
 				081383902AE004620055FDA2 /* LockScreenViewController.swift */,
+				081383942AE008810055FDA2 /* LockScreenNumCollectionViewCell.swift */,
 			);
 			path = LockScreenScene;
 			sourceTree = "<group>";
@@ -667,6 +670,7 @@
 				30E7984D2AD7E5A800903272 /* ProfilePageViewController.swift in Sources */,
 				084412112AD569AA005F2FA9 /* MainPageViewController.swift in Sources */,
 				08EB09312AD571CC00CCD51A /* Constant.swift in Sources */,
+				081383952AE008810055FDA2 /* LockScreenNumCollectionViewCell.swift in Sources */,
 				30E798552AD80AD500903272 /* ColorManager.swift in Sources */,
 				084411FB2AD56870005F2FA9 /* SceneDelegate.swift in Sources */,
 				037668B52ADE5CEA008BED0A /* commandLabelView.swift in Sources */,

--- a/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
+++ b/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		037668B52ADE5CEA008BED0A /* commandLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037668B42ADE5CEA008BED0A /* commandLabelView.swift */; };
 		038847D02AD7EF800083C420 /* PwFindViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038847CF2AD7EF800083C420 /* PwFindViewController.swift */; };
 		039B82BB2ADFDEAC00D3A73C /* PwFindPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037668AE2ADD101A008BED0A /* PwFindPageViewController.swift */; };
+		081383912AE004620055FDA2 /* LockScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081383902AE004620055FDA2 /* LockScreenViewController.swift */; };
 		083C985D2AD8D728006895D2 /* Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083C985C2AD8D728006895D2 /* Protocol.swift */; };
 		083C985F2AD8D7AC006895D2 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083C985E2AD8D7AC006895D2 /* Observable.swift */; };
 		083C98622AD8D88E006895D2 /* MemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083C98612AD8D88E006895D2 /* MemoViewModel.swift */; };
@@ -111,6 +112,7 @@
 		037668B22ADE56CB008BED0A /* buttonTappedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = buttonTappedView.swift; sourceTree = "<group>"; };
 		037668B42ADE5CEA008BED0A /* commandLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = commandLabelView.swift; sourceTree = "<group>"; };
 		038847CF2AD7EF800083C420 /* PwFindViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PwFindViewController.swift; sourceTree = "<group>"; };
+		081383902AE004620055FDA2 /* LockScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenViewController.swift; sourceTree = "<group>"; };
 		083C985C2AD8D728006895D2 /* Protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocol.swift; sourceTree = "<group>"; };
 		083C985E2AD8D7AC006895D2 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		083C98612AD8D88E006895D2 /* MemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoViewModel.swift; sourceTree = "<group>"; };
@@ -235,6 +237,14 @@
 			path = PwFindScene;
 			sourceTree = "<group>";
 		};
+		0813838F2AE0043A0055FDA2 /* LockScreenScene */ = {
+			isa = PBXGroup;
+			children = (
+				081383902AE004620055FDA2 /* LockScreenViewController.swift */,
+			);
+			path = LockScreenScene;
+			sourceTree = "<group>";
+		};
 		083C98602AD8D837006895D2 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
@@ -305,6 +315,7 @@
 				08A4F8882AD821410092C6EF /* MemoPageScene */,
 				083C98632AD8DB5F006895D2 /* AddMemoPageScene */,
 				083C986C2AD90103006895D2 /* AddMemoNotifySettingScene */,
+				0813838F2AE0043A0055FDA2 /* LockScreenScene */,
 			);
 			path = Scenes;
 			sourceTree = "<group>";
@@ -651,6 +662,7 @@
 				30E798832ADC122400903272 /* ThemeColorOptionManager.swift in Sources */,
 				084412172AD569E9005F2FA9 /* SignInPageViewController.swift in Sources */,
 				30445EBA2ADF1C81000D26A4 /* NetworkDataManager.swift in Sources */,
+				081383912AE004620055FDA2 /* LockScreenViewController.swift in Sources */,
 				30E798492AD6362D00903272 /* Extensions.swift in Sources */,
 				30E7984D2AD7E5A800903272 /* ProfilePageViewController.swift in Sources */,
 				084412112AD569AA005F2FA9 /* MainPageViewController.swift in Sources */,

--- a/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
+++ b/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		084412192AD569F4005F2FA9 /* SignUpPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084412182AD569F4005F2FA9 /* SignUpPageViewController.swift */; };
 		084412272AD56F21005F2FA9 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 084412262AD56F21005F2FA9 /* SnapKit */; };
 		085A52BE2ADEADD20041918D /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085A52BD2ADEADD20041918D /* LoginManager.swift */; };
+		0872CD902AE0B36300ABE980 /* LockScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0872CD8F2AE0B36300ABE980 /* LockScreenViewModel.swift */; };
 		08749B182ADBEE8D00822AE7 /* NotifySettingItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08749B172ADBEE8D00822AE7 /* NotifySettingItemView.swift */; };
 		08A4F88A2AD8216A0092C6EF /* MemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4F8892AD8216A0092C6EF /* MemoViewController.swift */; };
 		08A4F88C2AD8218E0092C6EF /* MemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4F88B2AD8218E0092C6EF /* MemoView.swift */; };
@@ -137,6 +138,7 @@
 		084412162AD569E9005F2FA9 /* SignInPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPageViewController.swift; sourceTree = "<group>"; };
 		084412182AD569F4005F2FA9 /* SignUpPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpPageViewController.swift; sourceTree = "<group>"; };
 		085A52BD2ADEADD20041918D /* LoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
+		0872CD8F2AE0B36300ABE980 /* LockScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenViewModel.swift; sourceTree = "<group>"; };
 		08749B172ADBEE8D00822AE7 /* NotifySettingItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifySettingItemView.swift; sourceTree = "<group>"; };
 		08A4F8892AD8216A0092C6EF /* MemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoViewController.swift; sourceTree = "<group>"; };
 		08A4F88B2AD8218E0092C6EF /* MemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoView.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 		0813838F2AE0043A0055FDA2 /* LockScreenScene */ = {
 			isa = PBXGroup;
 			children = (
+				0872CD8F2AE0B36300ABE980 /* LockScreenViewModel.swift */,
 				081383902AE004620055FDA2 /* LockScreenViewController.swift */,
 				081383942AE008810055FDA2 /* LockScreenNumCollectionViewCell.swift */,
 			);
@@ -676,6 +679,7 @@
 				037668B52ADE5CEA008BED0A /* commandLabelView.swift in Sources */,
 				C747DE302ADBDB640044499E /* AddMessagePageViewController.swift in Sources */,
 				084412192AD569F4005F2FA9 /* SignUpPageViewController.swift in Sources */,
+				0872CD902AE0B36300ABE980 /* LockScreenViewModel.swift in Sources */,
 				083C98672AD8DC08006895D2 /* PresentationController.swift in Sources */,
 				30E7987F2ADC074900903272 /* SettingOptionManager.swift in Sources */,
 			);

--- a/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
+++ b/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		084412272AD56F21005F2FA9 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 084412262AD56F21005F2FA9 /* SnapKit */; };
 		085A52BE2ADEADD20041918D /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085A52BD2ADEADD20041918D /* LoginManager.swift */; };
 		0872CD902AE0B36300ABE980 /* LockScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0872CD8F2AE0B36300ABE980 /* LockScreenViewModel.swift */; };
+		0872CD942AE0B46100ABE980 /* LockScreenPasswordCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0872CD932AE0B46100ABE980 /* LockScreenPasswordCollectionViewCell.swift */; };
 		08749B182ADBEE8D00822AE7 /* NotifySettingItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08749B172ADBEE8D00822AE7 /* NotifySettingItemView.swift */; };
 		08A4F88A2AD8216A0092C6EF /* MemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4F8892AD8216A0092C6EF /* MemoViewController.swift */; };
 		08A4F88C2AD8218E0092C6EF /* MemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4F88B2AD8218E0092C6EF /* MemoView.swift */; };
@@ -139,6 +140,7 @@
 		084412182AD569F4005F2FA9 /* SignUpPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpPageViewController.swift; sourceTree = "<group>"; };
 		085A52BD2ADEADD20041918D /* LoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
 		0872CD8F2AE0B36300ABE980 /* LockScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenViewModel.swift; sourceTree = "<group>"; };
+		0872CD932AE0B46100ABE980 /* LockScreenPasswordCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenPasswordCollectionViewCell.swift; sourceTree = "<group>"; };
 		08749B172ADBEE8D00822AE7 /* NotifySettingItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifySettingItemView.swift; sourceTree = "<group>"; };
 		08A4F8892AD8216A0092C6EF /* MemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoViewController.swift; sourceTree = "<group>"; };
 		08A4F88B2AD8218E0092C6EF /* MemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoView.swift; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 				0872CD8F2AE0B36300ABE980 /* LockScreenViewModel.swift */,
 				081383902AE004620055FDA2 /* LockScreenViewController.swift */,
 				081383942AE008810055FDA2 /* LockScreenNumCollectionViewCell.swift */,
+				0872CD932AE0B46100ABE980 /* LockScreenPasswordCollectionViewCell.swift */,
 			);
 			path = LockScreenScene;
 			sourceTree = "<group>";
@@ -659,6 +662,7 @@
 				30445EB42ADF12B4000D26A4 /* SettingModel+CoreDataProperties.swift in Sources */,
 				30445EB62ADF12B4000D26A4 /* MemoModel+CoreDataProperties.swift in Sources */,
 				08A4F88A2AD8216A0092C6EF /* MemoViewController.swift in Sources */,
+				0872CD942AE0B46100ABE980 /* LockScreenPasswordCollectionViewCell.swift in Sources */,
 				C735C0462AD8E16D00AA7663 /* AddNotifyPageViewController.swift in Sources */,
 				083C986E2AD90129006895D2 /* NotifySettingPageViewController.swift in Sources */,
 				6906BAA12AD91DBC0088FE6E /* MainPageView.swift in Sources */,

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenNumCollectionViewCell.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenNumCollectionViewCell.swift
@@ -1,0 +1,20 @@
+//
+//  LockScreenNumCollectionViewCell.swift
+//  FinalTodo
+//
+//  Created by SeoJunYoung on 10/18/23.
+//
+
+import UIKit
+
+class LockScreenNumCollectionViewCell: UICollectionViewCell {
+    
+    override init(frame: CGRect) {
+        super.init(frame: CGRect.zero)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenNumCollectionViewCell.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenNumCollectionViewCell.swift
@@ -9,15 +9,36 @@ import UIKit
 
 class LockScreenNumCollectionViewCell: UICollectionViewCell {
     
+    private let label: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .title1)
+        label.text = "test"
+        label.textAlignment = .center
+        label.textColor = ColorManager.themeArray[0].backgroundColor
+        return label
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: CGRect.zero)
-        contentView.backgroundColor = ColorManager.themeArray[0].pointColor02
-        let width = (Constant.screenWidth - (Constant.defaultPadding * 2) - (Constant.defaultPadding * 2)) / 3
-        contentView.layer.cornerRadius = width / 2
+        setUp()
+
     }
     
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension LockScreenNumCollectionViewCell {
+    func setUp() {
+        contentView.backgroundColor = ColorManager.themeArray[0].pointColor01
+        let spacing = Constant.defaultPadding * 2
+        let width = (Constant.screenWidth - (Constant.defaultPadding * 6) - (spacing * 2)) / 3
+        contentView.layer.cornerRadius = width / 2
+        contentView.addSubview(label)
+        label.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
     }
 }

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenNumCollectionViewCell.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenNumCollectionViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 
 class LockScreenNumCollectionViewCell: UICollectionViewCell {
     
@@ -14,7 +15,7 @@ class LockScreenNumCollectionViewCell: UICollectionViewCell {
         label.font = .preferredFont(forTextStyle: .title1)
         label.text = "test"
         label.textAlignment = .center
-        label.textColor = ColorManager.themeArray[0].backgroundColor
+        label.textColor = ColorManager.themeArray[0].pointColor01
         return label
     }()
     
@@ -28,11 +29,20 @@ class LockScreenNumCollectionViewCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    func bind(title: String) {
+        label.text = title
+    }
+    
+    func getTitle() -> String {
+        guard let text = label.text else {return ""}
+        return text
+    }
 }
 
 private extension LockScreenNumCollectionViewCell {
     func setUp() {
-        contentView.backgroundColor = ColorManager.themeArray[0].pointColor01
+        contentView.backgroundColor = ColorManager.themeArray[0].pointColor02
         let spacing = Constant.defaultPadding * 2
         let width = (Constant.screenWidth - (Constant.defaultPadding * 6) - (spacing * 2)) / 3
         contentView.layer.cornerRadius = width / 2

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenNumCollectionViewCell.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenNumCollectionViewCell.swift
@@ -11,6 +11,9 @@ class LockScreenNumCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: CGRect.zero)
+        contentView.backgroundColor = ColorManager.themeArray[0].pointColor02
+        let width = (Constant.screenWidth - (Constant.defaultPadding * 2) - (Constant.defaultPadding * 2)) / 3
+        contentView.layer.cornerRadius = width / 2
     }
     
     @available(*, unavailable)

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenPasswordCollectionViewCell.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenPasswordCollectionViewCell.swift
@@ -6,7 +6,32 @@
 //
 
 import UIKit
+import SnapKit
 
 class LockScreenPasswordCollectionViewCell: UICollectionViewCell {
+    override init(frame: CGRect) {
+        super.init(frame: CGRect.zero)
+        setUp()
+    }
     
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func bind(toggle: Bool) {
+        if toggle {
+            contentView.backgroundColor = ColorManager.themeArray[0].pointColor01
+        } else {
+            contentView.backgroundColor = ColorManager.themeArray[0].pointColor02
+        }
+        
+    }
+}
+
+private extension LockScreenPasswordCollectionViewCell {
+    func setUp() {
+        contentView.layer.cornerRadius = Constant.screenWidth * 0.05 / 2
+        contentView.backgroundColor = ColorManager.themeArray[0].pointColor02
+    }
 }

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenPasswordCollectionViewCell.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenPasswordCollectionViewCell.swift
@@ -1,0 +1,12 @@
+//
+//  LockScreenPasswordCollectionViewCell.swift
+//  FinalTodo
+//
+//  Created by SeoJunYoung on 10/19/23.
+//
+
+import UIKit
+
+class LockScreenPasswordCollectionViewCell: UICollectionViewCell {
+    
+}

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
@@ -34,6 +34,8 @@ class LockScreenViewController: UIViewController {
         view.backgroundColor = .clear
         return view
     }()
+    
+    private let viewModel = LockScreenViewModel()
 }
 
 extension LockScreenViewController {

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
@@ -6,24 +6,22 @@
 //
 
 import UIKit
+import SnapKit
 
 class LockScreenViewController: UIViewController {
+    
+    private let collectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        
+        let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        return view
+    }()
+}
 
+extension LockScreenViewController {
+    // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        view.backgroundColor = ColorManager.themeArray[0].backgroundColor
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
@@ -10,10 +10,14 @@ import SnapKit
 
 class LockScreenViewController: UIViewController {
     
-    private let collectionView: UICollectionView = {
+    private let numsCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
-        
+        let spacing = Constant.defaultPadding
+        let width = (Constant.screenWidth - (Constant.defaultPadding * 2) - (spacing * 2)) / 3
+        flowLayout.minimumLineSpacing = spacing
+        flowLayout.itemSize = .init(width: width, height: width)
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        view.backgroundColor = .clear
         return view
     }()
 }
@@ -22,6 +26,34 @@ extension LockScreenViewController {
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = ColorManager.themeArray[0].backgroundColor
+        setUp()
     }
+}
+
+private extension LockScreenViewController {
+    func setUp() {
+        view.backgroundColor = ColorManager.themeArray[0].backgroundColor
+        view.addSubview(numsCollectionView)
+        numsCollectionView.snp.makeConstraints { make in
+            make.top.bottom.equalToSuperview()
+            make.left.right.equalToSuperview().inset(Constant.defaultPadding)
+        }
+        numsCollectionView.delegate = self
+        numsCollectionView.dataSource = self
+        numsCollectionView.register(LockScreenNumCollectionViewCell.self, forCellWithReuseIdentifier: LockScreenNumCollectionViewCell.identifier)
+    }
+}
+
+extension LockScreenViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        12
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LockScreenNumCollectionViewCell.identifier, for: indexPath) as! LockScreenNumCollectionViewCell
+        
+        return cell
+    }
+    
+    
 }

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
@@ -1,0 +1,29 @@
+//
+//  LockScreenViewController.swift
+//  FinalTodo
+//
+//  Created by SeoJunYoung on 10/18/23.
+//
+
+import UIKit
+
+class LockScreenViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
@@ -10,11 +10,25 @@ import SnapKit
 
 class LockScreenViewController: UIViewController {
     
+    private let passwordLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .title1)
+        label.text = "암호 입력"
+        return label
+    }()
+    
+    private let passwordCollectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        view.backgroundColor = .green
+        return view
+    }()
+    
     private let numsCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
-        let spacing = Constant.defaultPadding
-        let width = (Constant.screenWidth - (Constant.defaultPadding * 2) - (spacing * 2)) / 3
-        flowLayout.minimumLineSpacing = spacing
+        let spacing = Constant.defaultPadding * 2
+        let width = (Constant.screenWidth - (Constant.defaultPadding * 6) - (spacing * 2)) / 3
+        flowLayout.minimumLineSpacing = spacing / 2
         flowLayout.itemSize = .init(width: width, height: width)
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.backgroundColor = .clear
@@ -34,9 +48,33 @@ private extension LockScreenViewController {
     func setUp() {
         view.backgroundColor = ColorManager.themeArray[0].backgroundColor
         view.addSubview(numsCollectionView)
+        setUpPasswordLabel()
+        setUpPasswordCollectionView()
+        setUpNumsCollectionView()
+    }
+    
+    func setUpPasswordLabel() {
+        view.addSubview(passwordLabel)
+        passwordLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(Constant.screenHeight * 0.15)
+            make.centerX.equalToSuperview()
+        }
+    }
+    
+    func setUpPasswordCollectionView() {
+        view.addSubview(passwordCollectionView)
+        passwordCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(passwordLabel.snp.bottom).offset(Constant.defaultPadding)
+            make.left.right.equalToSuperview()
+            make.height.equalTo(Constant.screenHeight * 0.05)
+        }
+    }
+    
+    func setUpNumsCollectionView() {
         numsCollectionView.snp.makeConstraints { make in
-            make.top.bottom.equalToSuperview()
-            make.left.right.equalToSuperview().inset(Constant.defaultPadding)
+            make.top.equalTo(passwordCollectionView.snp.bottom).offset(Constant.screenHeight * 0.1)
+            make.left.right.equalToSuperview().inset(Constant.defaultPadding * 3)
+            make.bottom.equalToSuperview()
         }
         numsCollectionView.delegate = self
         numsCollectionView.dataSource = self
@@ -46,14 +84,18 @@ private extension LockScreenViewController {
 
 extension LockScreenViewController: UICollectionViewDelegate, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        12
+        return 12
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LockScreenNumCollectionViewCell.identifier, for: indexPath) as! LockScreenNumCollectionViewCell
-        
-        return cell
+        if collectionView == passwordCollectionView {
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LockScreenNumCollectionViewCell.identifier, for: indexPath) as! LockScreenNumCollectionViewCell
+            
+            return cell
+        } else {
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LockScreenNumCollectionViewCell.identifier, for: indexPath) as! LockScreenNumCollectionViewCell
+            
+            return cell
+        }
     }
-    
-    
 }

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewController.swift
@@ -17,25 +17,40 @@ class LockScreenViewController: UIViewController {
         return label
     }()
     
-    private let passwordCollectionView: UICollectionView = {
+    lazy var passwordCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
-        let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
-        view.backgroundColor = .green
-        return view
-    }()
-    
-    private let numsCollectionView: UICollectionView = {
-        let flowLayout = UICollectionViewFlowLayout()
-        let spacing = Constant.defaultPadding * 2
-        let width = (Constant.screenWidth - (Constant.defaultPadding * 6) - (spacing * 2)) / 3
-        flowLayout.minimumLineSpacing = spacing / 2
-        flowLayout.itemSize = .init(width: width, height: width)
+        flowLayout.itemSize = .init(width: viewModel.passwordCollectionviewItemSize.width, height: viewModel.passwordCollectionviewItemSize.height)
+        flowLayout.minimumLineSpacing = viewModel.passwordCollectionviewSpacing
+        flowLayout.scrollDirection = .horizontal
         let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         view.backgroundColor = .clear
         return view
     }()
     
-    private let viewModel = LockScreenViewModel()
+    lazy var numsCollectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        let spacing = viewModel.numPadCollectionviewSpacing
+        flowLayout.minimumLineSpacing = spacing / 2
+        flowLayout.itemSize = .init(width: viewModel.numPadCollectionviewItemSize.width, height: viewModel.numPadCollectionviewItemSize.height)
+        let view = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        view.backgroundColor = .clear
+        return view
+    }()
+    
+    private let viewModel: LockScreenViewModel
+    
+    init(rootViewController: UIViewController, targetViewController: UIViewController) {
+        self.viewModel = LockScreenViewModel(rootViewController: rootViewController, targetViewController: targetViewController)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        print("[LockScreenViewController]: deinit")
+    }
 }
 
 extension LockScreenViewController {
@@ -43,13 +58,45 @@ extension LockScreenViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUp()
+        bind()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        self.navigationController?.navigationBar.isHidden = false
+        self.tabBarController?.tabBar.isHidden = false
     }
 }
 
 private extension LockScreenViewController {
+    
+    // MARK: - Bind
+    
+    func bind() {
+        viewModel.userInPutPassword.bind { [weak self] inputData in
+            guard let self = self else { return }
+            passwordCollectionView.reloadData()
+            if inputData.count == viewModel.lockScreenPassword.count {
+                if inputData == viewModel.lockScreenPassword {
+                    print("[LockScreenViewController]: 비밀번호 일치")
+                    self.navigationController?.popViewController(animated: false, completion: {
+                        let vc = self.viewModel.targetViewController
+                        self.viewModel.rootViewController.navigationController?.pushViewController(vc, animated: true)
+                    })
+                } else {
+                    print("[LockScreenViewController]: 비밀번호 불일치")
+                }
+            }
+        }
+    }
+
+    
+    // MARK: - SetUp
+
     func setUp() {
         view.backgroundColor = ColorManager.themeArray[0].backgroundColor
         view.addSubview(numsCollectionView)
+        self.navigationController?.navigationBar.isHidden = true
+        self.tabBarController?.tabBar.isHidden = true
         setUpPasswordLabel()
         setUpPasswordCollectionView()
         setUpNumsCollectionView()
@@ -68,8 +115,11 @@ private extension LockScreenViewController {
         passwordCollectionView.snp.makeConstraints { make in
             make.top.equalTo(passwordLabel.snp.bottom).offset(Constant.defaultPadding)
             make.left.right.equalToSuperview()
-            make.height.equalTo(Constant.screenHeight * 0.05)
+            make.height.equalTo(viewModel.passwordCollectionviewItemSize.height)
         }
+        passwordCollectionView.delegate = self
+        passwordCollectionView.dataSource = self
+        passwordCollectionView.register(LockScreenPasswordCollectionViewCell.self, forCellWithReuseIdentifier: LockScreenPasswordCollectionViewCell.identifier)
     }
     
     func setUpNumsCollectionView() {
@@ -85,19 +135,79 @@ private extension LockScreenViewController {
 }
 
 extension LockScreenViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 12
+        if collectionView == passwordCollectionView {
+            return viewModel.lockScreenPassword.count
+        } else {
+            return viewModel.numPadComposition.count
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if collectionView == passwordCollectionView {
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LockScreenNumCollectionViewCell.identifier, for: indexPath) as! LockScreenNumCollectionViewCell
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LockScreenPasswordCollectionViewCell.identifier, for: indexPath) as! LockScreenPasswordCollectionViewCell
+            if indexPath.row < viewModel.userInPutPassword.value.count {
+                cell.bind(toggle: true)
+            } else {
+                cell.bind(toggle: false)
+            }
             
             return cell
         } else {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LockScreenNumCollectionViewCell.identifier, for: indexPath) as! LockScreenNumCollectionViewCell
-            
+            cell.bind(title: viewModel.numPadComposition[indexPath.row])
             return cell
         }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        switch viewModel.numPadComposition[indexPath.row] {
+        case "AC":
+            viewModel.userInPutPassword.value = ""
+        case "C":
+            if viewModel.userInPutPassword.value.count != 0 {
+                let _ = viewModel.userInPutPassword.value.popLast()
+            }
+        default:
+            if viewModel.lockScreenPassword.count > viewModel.userInPutPassword.value.count {
+                viewModel.userInPutPassword.value += viewModel.numPadComposition[indexPath.row]
+            }
+        }
+    }
+    
+    
+}
+
+extension LockScreenViewController: UICollectionViewDelegateFlowLayout {
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        
+        if collectionView == passwordCollectionView {
+            let count = Double(viewModel.lockScreenPassword.count)
+            let totalCellWidth = viewModel.passwordCollectionviewItemSize.width * count
+            let totalSpacingWidth = viewModel.passwordCollectionviewSpacing * (count - 1)
+            let leftInset = (collectionView.bounds.width - CGFloat(totalCellWidth + totalSpacingWidth)) / 2
+            let rightInset = leftInset
+            return UIEdgeInsets(top: 0, left: leftInset, bottom: 0, right: rightInset)
+        }
+        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    }
+}
+
+
+extension UINavigationController {
+    func popViewController(animated: Bool, completion:@escaping (()->())) {
+        CATransaction.setCompletionBlock(completion)
+        CATransaction.begin()
+        _ = self.popViewController(animated: animated)
+        CATransaction.commit()
+    }
+    
+    func pushViewController(_ viewController: UIViewController, animated: Bool, completion:@escaping (()->())) {
+        CATransaction.setCompletionBlock(completion)
+        CATransaction.begin()
+        self.pushViewController(viewController, animated: animated)
+        CATransaction.commit()
     }
 }

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewModel.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewModel.swift
@@ -6,7 +6,44 @@
 //
 
 import Foundation
+import UIKit
 
 class LockScreenViewModel {
     
+//    init(rootViewController: UIViewController) {
+//        self.rootViewController = rootViewController
+//    }
+//    
+    init(rootViewController: UIViewController, targetViewController: UIViewController) {
+        self.rootViewController = rootViewController
+        self.targetViewController = targetViewController
+    }
+    let lockScreenPassword = "123456"
+    
+    let userInPutPassword: Observable<String> = Observable("")
+    
+    let passwordCollectionviewSpacing = Constant.defaultPadding
+    
+    let passwordCollectionviewItemSize: CGSize = .init(
+        width: Constant.screenWidth * 0.05,
+        height: Constant.screenWidth * 0.05
+    )
+    
+    let rootViewController: UIViewController
+    
+    let targetViewController: UIViewController
+    
+    let numPadComposition = [
+        "1", "2", "3",
+        "4", "5", "6",
+        "7", "8", "9",
+        "AC","0", "C"
+    ]
+    
+    let numPadCollectionviewSpacing = Constant.defaultPadding * 2
+    
+    lazy var numPadCollectionviewItemSize: CGSize = .init(
+        width: (Constant.screenWidth - (Constant.defaultPadding * 6) - (numPadCollectionviewSpacing * 2)) / 3,
+        height: (Constant.screenWidth - (Constant.defaultPadding * 6) - (numPadCollectionviewSpacing * 2)) / 3
+    )
 }

--- a/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewModel.swift
+++ b/FinalTodo/FinalTodo/Scenes/LockScreenScene/LockScreenViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  LockScreenViewModel.swift
+//  FinalTodo
+//
+//  Created by SeoJunYoung on 10/19/23.
+//
+
+import Foundation
+
+class LockScreenViewModel {
+    
+}


### PR DESCRIPTION
### LockScreenViewController 구현

## 작동방식
- 비밀번호 일치시 작동 방식 
1. RootView -> LockScreenView
2. 비밀번호 일치
3. LockScreenView dismiss
4. RootView -> TargetView present

## 사용법
```
@objc func searchButtonTapped() {
        let vc = LockScreenViewController(rootViewController: self, targetViewController: MemoViewController())
        self.navigationController?.pushViewController(vc, animated: true)
 }
```
- LockScreenViewController의 이니셜 라이저에서 RootViewController를 self로 지정후 TargetViewController는 잠금 해제 했을 때 연결 되는 Controller 기입

## 주의점
- 반드시 사용 ViewController는 NavigationController가 있어야 합니다.

## branch
- feat/privateFeature

## Image
![image](https://github.com/NBCampFinal5/FinalTodo/assets/112812473/1bea77a9-250c-47b5-b6fb-c9b0be509fa7)

