### PR TITLE
[FEAT] 페이지 전환 기능 구현

### DIFF
--- a/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
+++ b/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
@@ -82,7 +82,6 @@
 		08F8F47E2ADE5E9D0067D3E4 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 08F8F47D2ADE5E9D0067D3E4 /* FirebaseAppCheck */; };
 		08F8F4802ADE5FFF0067D3E4 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F8F47F2ADE5FFF0067D3E4 /* FirebaseManager.swift */; };
 		301B396E2AE134C200B19313 /* UserDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 301B39662AE134C200B19313 /* UserDataModel.xcdatamodeld */; };
-		301B39882AE7B5E000B19313 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 301B39872AE7B5E000B19313 /* GoogleService-Info.plist */; };
 		301B398A2AE7B60800B19313 /* ProfilePageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301B39892AE7B60800B19313 /* ProfilePageViewModel.swift */; };
 		301B39DE2AE93B9E00B19313 /* MemoModel+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301B39D82AE93B9D00B19313 /* MemoModel+CoreDataClass.swift */; };
 		301B39DF2AE93B9E00B19313 /* MemoModel+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301B39D92AE93B9E00B19313 /* MemoModel+CoreDataProperties.swift */; };
@@ -102,6 +101,8 @@
 		30E798552AD80AD500903272 /* ColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E798542AD80AD500903272 /* ColorManager.swift */; };
 		30E7987F2ADC074900903272 /* SettingOptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E7987E2ADC074900903272 /* SettingOptionManager.swift */; };
 		30E798832ADC122400903272 /* ThemeColorOptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E798822ADC122400903272 /* ThemeColorOptionManager.swift */; };
+		30F521842AEA3B5200DA1DD8 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 30F521832AEA3B5100DA1DD8 /* GoogleService-Info.plist */; };
+		30F521862AEA776F00DA1DD8 /* DeleteAccountPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F521852AEA776F00DA1DD8 /* DeleteAccountPageViewController.swift */; };
 		6906BA9D2AD695760088FE6E /* FolderDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906BA9C2AD695760088FE6E /* FolderDialogViewController.swift */; };
 		6906BA9F2AD8E8570088FE6E /* MemoListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906BA9E2AD8E8570088FE6E /* MemoListViewController.swift */; };
 		6906BAA12AD91DBC0088FE6E /* MainPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906BAA02AD91DBC0088FE6E /* MainPageView.swift */; };
@@ -168,7 +169,6 @@
 		08EB09302AD571CC00CCD51A /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		08F8F47F2ADE5FFF0067D3E4 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		301B39672AE134C200B19313 /* UserDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = UserDataModel.xcdatamodel; sourceTree = "<group>"; };
-		301B39872AE7B5E000B19313 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../GoogleService-Info.plist"; sourceTree = "<group>"; };
 		301B39892AE7B60800B19313 /* ProfilePageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePageViewModel.swift; sourceTree = "<group>"; };
 		301B39D82AE93B9D00B19313 /* MemoModel+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemoModel+CoreDataClass.swift"; sourceTree = "<group>"; };
 		301B39D92AE93B9E00B19313 /* MemoModel+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemoModel+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -188,6 +188,8 @@
 		30E798542AD80AD500903272 /* ColorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorManager.swift; sourceTree = "<group>"; };
 		30E7987E2ADC074900903272 /* SettingOptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingOptionManager.swift; sourceTree = "<group>"; };
 		30E798822ADC122400903272 /* ThemeColorOptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorOptionManager.swift; sourceTree = "<group>"; };
+		30F521832AEA3B5100DA1DD8 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../GoogleService-Info.plist"; sourceTree = "<group>"; };
+		30F521852AEA776F00DA1DD8 /* DeleteAccountPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountPageViewController.swift; sourceTree = "<group>"; };
 		6906BA9C2AD695760088FE6E /* FolderDialogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderDialogViewController.swift; sourceTree = "<group>"; };
 		6906BA9E2AD8E8570088FE6E /* MemoListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoListViewController.swift; sourceTree = "<group>"; };
 		6906BAA02AD91DBC0088FE6E /* MainPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageView.swift; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 			isa = PBXGroup;
 			children = (
 				084412062AD56871005F2FA9 /* Info.plist */,
+				30F521832AEA3B5100DA1DD8 /* GoogleService-Info.plist */,
 				084411F82AD56870005F2FA9 /* AppDelegate.swift */,
 				084411FA2AD56870005F2FA9 /* SceneDelegate.swift */,
 				084412012AD56871005F2FA9 /* Assets.xcassets */,
@@ -568,6 +571,7 @@
 			children = (
 				30E7984C2AD7E5A800903272 /* ProfilePageViewController.swift */,
 				301B39892AE7B60800B19313 /* ProfilePageViewModel.swift */,
+				30F521852AEA776F00DA1DD8 /* DeleteAccountPageViewController.swift */,
 			);
 			path = ProfilePageScene;
 			sourceTree = "<group>";
@@ -697,6 +701,7 @@
 			files = (
 				084412052AD56871005F2FA9 /* LaunchScreen.storyboard in Resources */,
 				084412022AD56871005F2FA9 /* Assets.xcassets in Resources */,
+				30F521842AEA3B5200DA1DD8 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -739,6 +744,7 @@
 				30E798522AD7F51200903272 /* ThemeColorOption.swift in Sources */,
 				C747DE272ADBBCE90044499E /* DdayPageModel.swift in Sources */,
 				30E798472AD61E0B00903272 /* SettingOption.swift in Sources */,
+				30F521862AEA776F00DA1DD8 /* DeleteAccountPageViewController.swift in Sources */,
 				08A4F88C2AD8218E0092C6EF /* MemoView.swift in Sources */,
 				C735C05F2AD9466C00AA7663 /* CalendarPageView.swift in Sources */,
 				08487F952AE558BA009AE6CB /* UserDefaultsManager.swift in Sources */,

--- a/FinalTodo/FinalTodo/Resource/SceneDelegate.swift
+++ b/FinalTodo/FinalTodo/Resource/SceneDelegate.swift
@@ -15,24 +15,24 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let tabBar = TabBarController()
         window = UIWindow(windowScene: windowScene)
         window?.backgroundColor = .systemBackground
-        window?.rootViewController = UINavigationController(rootViewController: SignInPageViewController())
+        window?.rootViewController = tabBar
         window?.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
-        print("[SceneDelegate]:",#function)
+        print("[SceneDelegate]:", #function)
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        print("[SceneDelegate]:",#function)
+        print("[SceneDelegate]:", #function)
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
-        print("[SceneDelegate]:",#function)
+        print("[SceneDelegate]:", #function)
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        print("[SceneDelegate]:",#function)
+        print("[SceneDelegate]:", #function)
         let manager = UserDefaultsManager()
         if manager.getLockIsOn() {
             guard let rootViewController = window?.rootViewController else { return }
@@ -41,19 +41,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        print("[SceneDelegate]:",#function)
+        print("[SceneDelegate]:", #function)
     }
-    
-
 }
 
 extension SceneDelegate {
     // MARK: - RootViewChangeMethod
 
     func changeRootVC(viewController: UIViewController, animated: Bool) {
-        guard let window = self.window else { return }
+        guard let window = window else { return }
         window.rootViewController = viewController
         UIView.transition(with: window, duration: 0.5, options: [.transitionCrossDissolve], animations: nil, completion: nil)
     }
 }
-

--- a/FinalTodo/FinalTodo/Resource/SceneDelegate.swift
+++ b/FinalTodo/FinalTodo/Resource/SceneDelegate.swift
@@ -13,9 +13,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let tabBar = TabBarController()
+        let signInVC = UINavigationController(rootViewController: SignInPageViewController())
         window = UIWindow(windowScene: windowScene)
         window?.backgroundColor = .systemBackground
-        window?.rootViewController = tabBar
+        window?.rootViewController = signInVC // tabBar
         window?.makeKeyAndVisible()
     }
 

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SginInScene/SignInPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SginInScene/SignInPageViewController.swift
@@ -5,18 +5,17 @@
 //  Created by SeoJunYoung on 2023/10/10.
 //
 
-import UIKit
 import SnapKit
+import UIKit
 
 // TODO: - Font -> 지정 폰트로 변경
 // TODO: - 공용뷰로 작업.
 // TODO: - AutoLayout은 상수 x 화면 비율로 계산
 // TODO: - 들여쓰기
 
-//로그인페이지
-class SignInPageViewController: UIViewController, CommandLabelDelegate{
-    
-    //맨위에 로그인 굵은글자
+// 로그인페이지
+class SignInPageViewController: UIViewController, CommandLabelDelegate {
+    // 맨위에 로그인 굵은글자
     private lazy var loginLabel: UILabel = {
         let label = UILabel()
         label.text = "로그인"
@@ -24,67 +23,65 @@ class SignInPageViewController: UIViewController, CommandLabelDelegate{
         label.textColor = UIColor(named: "theme01PointColor01")
         return label
     }()
+
     let loginBar = CommandLabelView(title: "아이디", placeholder: "아이디를 입력해주세요.", isSecureTextEntry: false)
     let passwordBar = CommandLabelView(title: "비밀번호", placeholder: "비밀번호를 입력해주세요.", isSecureTextEntry: true)
     let loginButton = ButtonTappedView(title: "로그인")
     let haveAccountButton = ButtonTappedView(title: "가입이 필요하신가요?")
-    
+
 //    private let viewModel = SignInPageViewModel()
-    
 }
+
 extension SignInPageViewController {
     // MARK: - LifeCycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
         loginBar.delegate = self
         passwordBar.delegate = self
         loginButton.delegate = self
         haveAccountButton.delegate = self
-        self.view.backgroundColor = .white
+        view.backgroundColor = .white
         haveAccountButton.changeButtonColor(color: .white)
         haveAccountButton.changeTitleColor(color: .black)
         setUp()
     }
 }
 
-
 private extension SignInPageViewController {
     // MARK: - SetUp
-    
+
     func setUp() {
         setUpUserName()
         setUpPasswordName()
         setUpButton()
-        
     }
-    
+
     func setUpUserName() {
         view.addSubview(loginLabel)
-        //맨위 로그인레이블 오토레이아웃
+        // 맨위 로그인레이블 오토레이아웃
         loginLabel.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).inset(Constant.screenHeight * 0.07)
             make.leading.equalTo(Constant.defaultPadding)
         }
-        
+
         view.addSubview(loginBar)
-        //로그인텍스트
+        // 로그인텍스트
         loginBar.snp.makeConstraints { make in
             make.top.equalTo(loginLabel.snp.bottom).offset(Constant.screenHeight * 0.05)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
         }
     }
-    
-    
+
     func setUpPasswordName() {
-        
         view.addSubview(passwordBar)
-        //패스워드 텍스트
+        // 패스워드 텍스트
         passwordBar.snp.makeConstraints { make in
             make.top.equalTo(loginBar.snp.bottom).offset(Constant.screenHeight * 0.03)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
         }
     }
-    
+
     func setUpButton() {
         view.addSubview(loginButton)
         loginButton.snp.makeConstraints { make in
@@ -92,7 +89,7 @@ private extension SignInPageViewController {
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
             make.height.equalTo(Constant.screenHeight * 0.05)
         }
-        
+
         view.addSubview(haveAccountButton)
         haveAccountButton.snp.makeConstraints { make in
             make.top.equalTo(loginButton.snp.bottom).offset(Constant.screenHeight * 0.05)
@@ -102,18 +99,16 @@ private extension SignInPageViewController {
     }
 }
 
-
 extension SignInPageViewController {
     // MARK: - Method
-    
-    //빈곳 누르면 키보드 내려가는 함수
+
+    // 빈곳 누르면 키보드 내려가는 함수
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.view.endEditing(true)
+        view.endEditing(true)
     }
-    
-  
-    //로그인 버튼 색갈 바뀌는 함수
-    @objc func textFieldEditingChanged(_ textField : UITextField){
+
+    // 로그인 버튼 색갈 바뀌는 함수
+    @objc func textFieldEditingChanged(_ textField: UITextField) {
         if textField.text?.count == 1 {
             if textField.text?.first == " " {
                 textField.text = ""
@@ -130,18 +125,13 @@ extension SignInPageViewController {
         }
         loginButton.changeButtonColor(color: UIColor(named: "theme01PointColor01"))
         loginButton.setButtonEnabled(true)
-        
     }
-    //로그인버튼 누르면 다음화면으로 넘어가는 것 구현
-    @objc func didTapButton(){
 
-
-    }
-    
+    // 로그인버튼 누르면 다음화면으로 넘어가는 것 구현
+    @objc func didTapButton() {}
 }
 
 extension SignInPageViewController: ButtonTappedViewDelegate {
-    
     func didTapButton(button: UIButton) {
 //        guard let email = loginBar.inputTextField.text else { return }
 //        guard let password = passwordBar.inputTextField.text else { return }
@@ -153,6 +143,9 @@ extension SignInPageViewController: ButtonTappedViewDelegate {
 //                print("LoginFail")
 //            }
 //        }
+
+        // 서령: 로그인 버튼 클릭 시 씬델리게이트의 루트뷰 컨트롤러 탭바로 변경
+        let tabbar = TabBarController()
+        (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVC(viewController: tabbar, animated: true)
     }
-    
 }

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/DeleteAccountPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/DeleteAccountPageViewController.swift
@@ -43,7 +43,13 @@ class DeleteAccountPageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+//        navigationController?.navigationBar.isHidden = false
         setUp()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+//        navigationController?.navigationBar.isHidden = true
     }
 }
 
@@ -99,8 +105,9 @@ private extension DeleteAccountPageViewController {
 
     func deleteAccount() {
         let signInPageVC = SignInPageViewController()
-        navigationController?.pushViewController(signInPageVC, animated: true)
-
+//        navigationController?.pushViewController(signInPageVC, animated: true)
+//        navigationController?.popViewController(animated: true)
+//        navigationController?.popToViewController(signInPageVC, animated: true)
 //        modalPresentationStyle = .overFullScreen
 //        present(signInPageVC, animated: true)
         print("계정 삭제 완료")

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/DeleteAccountPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/DeleteAccountPageViewController.swift
@@ -104,12 +104,11 @@ private extension DeleteAccountPageViewController {
     }
 
     func deleteAccount() {
-        let signInPageVC = SignInPageViewController()
-//        navigationController?.pushViewController(signInPageVC, animated: true)
-//        navigationController?.popViewController(animated: true)
-//        navigationController?.popToViewController(signInPageVC, animated: true)
-//        modalPresentationStyle = .overFullScreen
-//        present(signInPageVC, animated: true)
+        // 데이터베이스 유저 정보 삭제 로직 추가 필요
+
+        let signInVC = SignInPageViewController()
+        (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVC(viewController: signInVC, animated: true)
+
         print("계정 삭제 완료")
     }
 }

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/DeleteAccountPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/DeleteAccountPageViewController.swift
@@ -1,0 +1,108 @@
+//
+//  DeleteAccountPageViewController.swift
+//  FinalTodo
+//
+//  Created by SR on 2023/10/26.
+//
+
+import UIKit
+
+class DeleteAccountPageViewController: UIViewController {
+    private lazy var giniImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "gini1")
+        imageView.contentMode = .scaleAspectFill
+        return imageView
+    }()
+
+    private lazy var giniChatLabel: UILabel = {
+        let label = UILabel()
+        label.text = "정말... 계정 삭제하실 건가요?"
+        label.font = UIFont.preferredFont(forTextStyle: .title1)
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private let deleteAccountButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("계정 삭제", for: .normal)
+        button.setTitleColor(.red, for: .normal)
+        return button
+    }()
+
+    private lazy var allertLabel: UILabel = {
+        let label = UILabel()
+        label.text = "*주의*\n계정 삭제 시 \n폴더·메모·기니피그 데이터가 함께 삭제됩니다."
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.textColor = UIColor.systemGray
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUp()
+    }
+}
+
+private extension DeleteAccountPageViewController {
+    func setUp() {
+        title = "계정 삭제"
+        view.backgroundColor = ColorManager.themeArray[0].backgroundColor
+
+        deleteAccountButton.addTarget(self, action: #selector(DidTapDeleteAccountButton), for: .touchUpInside)
+
+        view.addSubview(giniChatLabel)
+        view.addSubview(giniImageView)
+        view.addSubview(allertLabel)
+        view.addSubview(deleteAccountButton)
+
+        giniChatLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(Constant.defaultPadding)
+            make.centerX.equalToSuperview()
+        }
+
+        giniImageView.snp.makeConstraints { make in
+            make.top.equalTo(giniChatLabel.snp.bottom).offset(Constant.defaultPadding)
+            make.height.equalTo(Constant.screenHeight * 0.45)
+            make.centerX.equalToSuperview()
+        }
+
+        allertLabel.snp.makeConstraints { make in
+            make.top.equalTo(giniImageView.snp.bottom)
+            make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
+        }
+
+        deleteAccountButton.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(Constant.defaultPadding)
+            make.centerX.equalToSuperview()
+        }
+    }
+
+    @objc
+    func DidTapDeleteAccountButton() {
+        let alert = UIAlertController(title: "계정 삭제", message: "사용자 계정을 영구 삭제합니다.", preferredStyle: .alert)
+
+        let confirmAction = UIAlertAction(title: "확인", style: .destructive) { [weak self] _ in
+            self?.deleteAccount()
+        }
+
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+
+        alert.addAction(confirmAction)
+        alert.addAction(cancelAction)
+
+        present(alert, animated: true, completion: nil)
+    }
+
+    func deleteAccount() {
+        let signInPageVC = SignInPageViewController()
+        navigationController?.pushViewController(signInPageVC, animated: true)
+
+//        modalPresentationStyle = .overFullScreen
+//        present(signInPageVC, animated: true)
+        print("계정 삭제 완료")
+    }
+}

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/DeleteAccountPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/DeleteAccountPageViewController.swift
@@ -43,13 +43,11 @@ class DeleteAccountPageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-//        navigationController?.navigationBar.isHidden = false
         setUp()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-//        navigationController?.navigationBar.isHidden = true
     }
 }
 

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewController.swift
@@ -8,22 +8,18 @@
 import SnapKit
 import UIKit
 
-// 과제1: 얼러트로 유저닉네임이랑 리워드닉네임 바꾼 게 바로 뷰컨트롤러에 반영이 안 되는 것
-// 과제2: 프로필페이지에서 다른 탭 눌렀다가 설정탭 돌아오면 그대로 프로필페이지인 것
-// 과제3: 계정 삭제 뒤 로그인페이지로 돌아가는 화면 전환이 모달로 된 것
-
 class ProfilePageViewController: UIViewController {
     private let viewModel = ProfilePageViewModel()
 
     lazy var userNickNameText = viewModel.userNickName {
-        didSet(newValue) {
-            userNickNameEditButton.setTitle(newValue, for: .normal)
+        didSet {
+            userNickNameEditButton.setTitle("안녕하세요, <\(userNickNameText)> 님!", for: .normal)
         }
     }
 
     lazy var rewardNickNameText = viewModel.rewardNickName {
-        didSet(newValue) {
-            rewardNickNameEditButton.setTitle(newValue, for: .normal)
+        didSet {
+            rewardNickNameEditButton.setTitle("<\(rewardNickNameText)>랑 메모 쓰러 가요!", for: .normal)
         }
     }
 
@@ -67,14 +63,10 @@ class ProfilePageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        viewModel.fetchUserData()
+        viewModel.fetchUserData {
+            print("@@")
+        }
         setUp()
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-//        rewardImageButton.layer.cornerRadius = rewardImageButton.frame.size.width / 2
-//        rewardImageButton.clipsToBounds = true
     }
 }
 
@@ -120,7 +112,7 @@ private extension ProfilePageViewController {
         }
     }
 
-    func showEditAlert(editType: ProfilePageViewModel.EditType) {
+    func showEditAlert(editType: ProfilePageViewModel.EditType, completion: @escaping () -> Void) {
         let title: String
 
         switch editType {
@@ -144,8 +136,8 @@ private extension ProfilePageViewController {
                 case .rewardNickName:
                     self.viewModel.updateNickName(type: .rewardNickName, newName: newNickName)
                 }
-                self.viewModel.fetchUserData()
             }
+            completion()
         }
         let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
 
@@ -157,18 +149,20 @@ private extension ProfilePageViewController {
 
     @objc
     func didTapUserNickNameEditButton(_ sender: UIButton) {
-        showEditAlert(editType: ProfilePageViewModel.EditType.userNickName)
-        sender.setTitle("안녕하세요, <\(userNickNameText)> 님!", for: .normal)
-//        sender.setNeedsLayout()
-//        sender.layoutIfNeeded()
+        showEditAlert(editType: ProfilePageViewModel.EditType.userNickName) {
+            self.viewModel.fetchUserData {
+                self.userNickNameText = self.viewModel.userNickName
+            }
+        }
     }
 
     @objc
     func didTapRewardNickNameEditButton(_ sender: UIButton) {
-        showEditAlert(editType: ProfilePageViewModel.EditType.rewardNickName)
-        sender.setTitle("<\(rewardNickNameText)>랑 메모 쓰러 가요!", for: .normal)
-//        sender.setNeedsLayout()
-//        sender.layoutIfNeeded()
+        showEditAlert(editType: ProfilePageViewModel.EditType.rewardNickName) {
+            self.viewModel.fetchUserData {
+                self.rewardNickNameText = self.viewModel.rewardNickName
+            }
+        }
     }
 
     @objc

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewController.swift
@@ -8,137 +8,172 @@
 import SnapKit
 import UIKit
 
+// 과제1: 얼러트로 유저닉네임이랑 리워드닉네임 바꾼 게 바로 뷰컨트롤러에 반영이 안 되는 것
+// 과제2: 프로필페이지에서 다른 탭 눌렀다가 설정탭 돌아오면 그대로 프로필페이지인 것
+// 과제3: 계정 삭제 뒤 로그인페이지로 돌아가는 화면 전환이 모달로 된 것
+
 class ProfilePageViewController: UIViewController {
-    let viewModel = ProfilePageViewModel()
+    private let viewModel = ProfilePageViewModel()
 
-    lazy var idLabel: UILabel = {
-        let label = UILabel()
-        label.text = viewModel.idLabelText
-        label.font = UIFont.preferredFont(forTextStyle: .largeTitle)
-        return label
+    lazy var userNickNameText = viewModel.userNickName {
+        didSet(newValue) {
+            userNickNameEditButton.setTitle(newValue, for: .normal)
+        }
+    }
+
+    lazy var rewardNickNameText = viewModel.rewardNickName {
+        didSet(newValue) {
+            rewardNickNameEditButton.setTitle(newValue, for: .normal)
+        }
+    }
+
+    private lazy var rewardImageButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(named: viewModel.giniImage), for: .normal)
+        button.layer.borderWidth = 2.0
+        button.layer.borderColor = UIColor.black.cgColor
+        button.addTarget(self, action: #selector(didTapGiniImageButton), for: .touchUpInside)
+        button.backgroundColor = .systemBackground
+        return button
     }()
 
-    lazy var nickNameLabel: CommandLabelView = {
-        let title = "닉네임"
-        let placeholder = viewModel.nickNameLabelPlaceholder
-        let view = CommandLabelView(title: title, placeholder: placeholder, isSecureTextEntry: false)
-        return view
+    private lazy var userNickNameEditButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("안녕하세요, <\(userNickNameText)> 님!", for: .normal)
+        button.setTitleColor(.label, for: .normal)
+        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .title2)
+        button.backgroundColor = .systemGray4
+        button.addTarget(self, action: #selector(didTapUserNickNameEditButton), for: .touchUpInside)
+        return button
     }()
 
-    lazy var passwordLabel: CommandLabelView = {
-        let title = "비밀번호"
-        let placeholder = viewModel.passwordLabelPlaceholder
-        let view = CommandLabelView(title: title, placeholder: placeholder, isSecureTextEntry: true)
-        return view
+    private lazy var rewardNickNameEditButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("<\(rewardNickNameText)>랑 메모 쓰러 가요!", for: .normal)
+        button.setTitleColor(.label, for: .normal)
+        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .title2)
+        button.backgroundColor = .systemGray4
+        button.addTarget(self, action: #selector(didTapRewardNickNameEditButton), for: .touchUpInside)
+        return button
     }()
 
-    lazy var passwordCheckLabel: CommandLabelView = {
-        let title = "비밀번호 확인"
-        let placeholder = viewModel.passwordCheckLabelPlaceholder
-        let view = CommandLabelView(title: title, placeholder: placeholder, isSecureTextEntry: true)
-        return view
-    }()
-
-    lazy var editButton: ButtonTappedView = {
-        let title = "수정"
-        let view = ButtonTappedView(title: title)
-        return view
-    }()
-
-    lazy var allertLabel: UILabel = {
-        let label = UILabel()
-        label.text = "비밀번호가 일치하지 않습니다!"
-        label.font = UIFont.preferredFont(forTextStyle: .caption1)
-        label.textColor = .red
-        label.isHidden = true
-        return label
+    private lazy var deleteAccountButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("계정 삭제", for: .normal)
+        button.setTitleColor(.red, for: .normal)
+        button.addTarget(self, action: #selector(didTapDeleteAccountButton), for: .touchUpInside)
+        return button
     }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        viewModel.fetchUserData()
         setUp()
-        bind()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+//        rewardImageButton.layer.cornerRadius = rewardImageButton.frame.size.width / 2
+//        rewardImageButton.clipsToBounds = true
     }
 }
 
 private extension ProfilePageViewController {
     func setUp() {
-        view.backgroundColor = .systemBackground
         title = "프로필"
-        
-        // 프로토콜 델리게이트 패턴
-        nickNameLabel.delegate = self
-        passwordLabel.delegate = self
-        passwordCheckLabel.delegate = self
-        editButton.delegate = self
+        view.backgroundColor = ColorManager.themeArray[0].backgroundColor
 
-        view.addSubview(idLabel)
-        view.addSubview(nickNameLabel)
-        view.addSubview(passwordLabel)
-        view.addSubview(passwordCheckLabel)
-        view.addSubview(editButton)
-        view.addSubview(allertLabel)
+        view.addSubview(rewardImageButton)
+        view.addSubview(userNickNameEditButton)
+        view.addSubview(rewardNickNameEditButton)
+        view.addSubview(deleteAccountButton)
 
-        idLabel.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(Constant.screenHeight * 0.1)
+        rewardImageButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(Constant.screenHeight * 0.05)
+            make.centerX.equalToSuperview()
+            make.width.height.equalTo(Constant.screenWidth * 0.3)
+        }
+
+        userNickNameEditButton.snp.makeConstraints { make in
+            make.top.equalTo(rewardImageButton.snp.bottom).offset(Constant.screenHeight * 0.07)
+            make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
+            make.height.equalTo(Constant.screenHeight * 0.05)
+        }
+
+        rewardNickNameEditButton.snp.makeConstraints { make in
+            make.top.equalTo(userNickNameEditButton.snp.bottom).offset(Constant.defaultPadding)
+            make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
+            make.height.equalTo(Constant.screenHeight * 0.05)
+        }
+
+        deleteAccountButton.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(Constant.defaultPadding)
             make.centerX.equalToSuperview()
         }
+    }
 
-        nickNameLabel.snp.makeConstraints { make in
-            make.top.equalTo(idLabel.snp.bottom).offset(Constant.screenHeight * 0.05)
-            make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
-        }
-
-        passwordLabel.snp.makeConstraints { make in
-            make.top.equalTo(nickNameLabel.snp.bottom).offset(Constant.screenHeight * 0.03)
-            make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
-        }
-
-        passwordCheckLabel.snp.makeConstraints { make in
-            make.top.equalTo(passwordLabel.snp.bottom).offset(Constant.screenHeight * 0.03)
-            make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
-        }
-
-        allertLabel.snp.makeConstraints { make in
-            make.top.equalTo(passwordCheckLabel.snp.bottom).offset(Constant.screenHeight * 0.01)
-            make.centerX.equalToSuperview()
-        }
-
-        editButton.snp.makeConstraints { make in
-            make.top.equalTo(passwordCheckLabel.snp.bottom).offset(Constant.screenHeight * 0.05)
-            make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
+    @objc
+    func didTapGiniImageButton(_ sender: UIButton) {
+        navigationController?.popViewController(animated: true)
+        if let tabBarController = tabBarController {
+            tabBarController.selectedIndex = 2
         }
     }
 
-    func bind() {
-        viewModel.fetchDataFromFirebase() // 파이어베이스에서 유저 정보 가져오기 함수 호출
-    }
-}
+    func showEditAlert(editType: ProfilePageViewModel.EditType) {
+        let title: String
 
-extension ProfilePageViewController: ButtonTappedViewDelegate {
-    func didTapButton(button: UIButton) {
-        print("🟢didTapButton🟢")
-        viewModel.nickNameLabelUserInput = nickNameLabel.inputTextField.text ?? ""
-        viewModel.passwordLabelUserInput = passwordLabel.inputTextField.text ?? ""
-        viewModel.passwordCheckLabelUserInput = passwordCheckLabel.inputTextField.text ?? ""
+        switch editType {
+        case .userNickName:
+            title = "유저 닉네임 변경"
+        case .rewardNickName:
+            title = "리워드 닉네임 변경"
+        }
 
-        viewModel.updateUserData() // 유저데이터 업데이트 함수 호출
-    }
-}
+        let alertController = UIAlertController(title: title, message: "닉네임을 입력해주세요.", preferredStyle: .alert)
 
-extension ProfilePageViewController: CommandLabelDelegate {
-    func textFieldEditingChanged(_ textField: UITextField) {
-        print("🟢textFieldDidEndEditing🟢")
-        if textField == passwordCheckLabel.inputTextField {
-            let newPassword = passwordLabel.inputTextField.text ?? ""
-            let newPasswordCheck = passwordCheckLabel.inputTextField.text ?? ""
+        alertController.addTextField { textField in
+            textField.placeholder = "새로운 닉네임"
+        }
 
-            // 비밀번호와 비밀번호 확인 값이 다르면 allertLabelText를 표시
-            if newPassword != newPasswordCheck {
-                allertLabel.isHidden = false
-            } else {
-                allertLabel.isHidden = true
+        let saveAction = UIAlertAction(title: "저장", style: .default) { _ in
+            if let textField = alertController.textFields?.first, let newNickName = textField.text {
+                switch editType {
+                case .userNickName:
+                    self.viewModel.updateNickName(type: .userNickName, newName: newNickName)
+                case .rewardNickName:
+                    self.viewModel.updateNickName(type: .rewardNickName, newName: newNickName)
+                }
+                self.viewModel.fetchUserData()
             }
         }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+
+        alertController.addAction(saveAction)
+        alertController.addAction(cancelAction)
+
+        present(alertController, animated: true, completion: nil)
+    }
+
+    @objc
+    func didTapUserNickNameEditButton(_ sender: UIButton) {
+        showEditAlert(editType: ProfilePageViewModel.EditType.userNickName)
+        sender.setTitle("안녕하세요, <\(userNickNameText)> 님!", for: .normal)
+//        sender.setNeedsLayout()
+//        sender.layoutIfNeeded()
+    }
+
+    @objc
+    func didTapRewardNickNameEditButton(_ sender: UIButton) {
+        showEditAlert(editType: ProfilePageViewModel.EditType.rewardNickName)
+        sender.setTitle("<\(rewardNickNameText)>랑 메모 쓰러 가요!", for: .normal)
+//        sender.setNeedsLayout()
+//        sender.layoutIfNeeded()
+    }
+
+    @objc
+    func didTapDeleteAccountButton(_ sender: UIButton) {
+        let deleteAccountPageVC = DeleteAccountPageViewController()
+        navigationController?.pushViewController(deleteAccountPageVC, animated: true)
     }
 }

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewController.swift
@@ -8,7 +8,6 @@
 import SnapKit
 import UIKit
 
-// 인셋 테이블뷰로 변경 -> 닉네임(변경) 리워드네임(변경) / 인셋 테이블뷰(클릭 불가) -> [아이디.닉네임.리워드네임.리워드포인트]
 class ProfilePageViewController: UIViewController {
     private let viewModel = ProfilePageViewModel()
 
@@ -64,18 +63,10 @@ class ProfilePageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-//        navigationController?.navigationBar.isHidden = false
         viewModel.fetchUserData {
-            print("@@")
+            print("@@viewDidLoad")
         }
         setUp()
-    }
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(true)
-    }
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-//        navigationController?.popToRootViewController(animated: true)
     }
 }
 

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewController.swift
@@ -8,6 +8,7 @@
 import SnapKit
 import UIKit
 
+// 인셋 테이블뷰로 변경 -> 닉네임(변경) 리워드네임(변경) / 인셋 테이블뷰(클릭 불가) -> [아이디.닉네임.리워드네임.리워드포인트]
 class ProfilePageViewController: UIViewController {
     private let viewModel = ProfilePageViewModel()
 
@@ -63,10 +64,18 @@ class ProfilePageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+//        navigationController?.navigationBar.isHidden = false
         viewModel.fetchUserData {
             print("@@")
         }
         setUp()
+    }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(true)
+    }
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+//        navigationController?.popToRootViewController(animated: true)
     }
 }
 

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewModel.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewModel.swift
@@ -20,16 +20,22 @@ class ProfilePageViewModel {
     var rewardNickName: String = "gini"
     var giniImage: String = "gini1"
 
-    func fetchUserData() {
+    func fetchUserData(completion: @escaping () -> Void) {
         userId = manager.getUser().id
         userFolders = manager.getUser().folders
         userFoldersMemos = manager.getUser().memos
         userThemeColor = manager.getUser().themeColor
 
         userPoint = manager.getUser().rewardPoint
-        userNickName = manager.getUser().nickName // 유저 닉네임
-        rewardNickName = manager.getUser().rewardName // 리워드 닉네임
+        userNickName = manager.getUser().nickName
+        rewardNickName = manager.getUser().rewardName 
 
+        fetchGiniImage(point: userPoint)
+        print("@@ 유저 패치!")
+        completion()
+    }
+
+    private func fetchGiniImage(point: Int32) {
         if userPoint >= 30 {
             giniImage = "gini4"
         } else if userPoint >= 20 {
@@ -39,9 +45,6 @@ class ProfilePageViewModel {
         } else {
             giniImage = "gini1"
         }
-        
-        print("@@ 유저 패치! user:\(userNickName), giniName: \(rewardNickName), giniImage: \(giniImage)")
-        print("@@ 현재 패치된 유저 정보:", manager.getUser())
     }
 
     enum EditType {

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewModel.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewModel.swift
@@ -8,36 +8,60 @@
 import UIKit
 
 class ProfilePageViewModel {
-//    let firebaseManager = FirebaseManager()
-    
-    var idLabelText: String = "eagle5@gmail.com" // 사용자 아이디(이메일) 받아오기
-    
-    var nickNameLabelPlaceholder: String = "짱짱독수리" // 사용자 닉네임 받아오기
-    var nickNameLabelUserInput: String = ""
-    
-    var passwordLabelPlaceholder: String = "******" // 사용자 비밀번호 받아오기
-    var passwordLabelUserInput: String = ""
+    private let manager = CoreDataManager.shared
 
-    var passwordCheckLabelPlaceholder: String = "******" // 사용자 비밀번호 받아오기
-    var passwordCheckLabelUserInput: String = ""
-    
-    var editButtonColor: Int = 1 // 사용자 지정 테마컬러 받아오기
-    
-    var allertLabelTextIsHidden: Bool = true // 텍스트필드 isHidden 불값 -> 기본값은 true, passwordLabelUserInput사용자 입력값, passwordCheckLabelUserInput 사용자 입력값이 다를 때 isHidden = false
-    
-    func fetchDataFromFirebase() {
-//        firebaseManager.fetchUserData(email: idLabelText) { [weak self] user in
-////            self?.idLabelText = user.id
-//            self?.nickNameLabelPlaceholder = user.nickName
-////            self?.passwordLabelPlaceholder = user.password // User 모델에 비밀번호 추가 필요????
-////            self?.passwordCheckLabelPlaceholder = user.password
-//            self?.editButtonColor = user.themeColor
-//        }
+    private var userId: String = "userId"
+    private var userFolders: [FolderData] = []
+    private var userFoldersMemos: [MemoData] = []
+    private var userPoint: Int32 = 0
+    private var userThemeColor = ""
+
+    var userNickName: String = "user"
+    var rewardNickName: String = "gini"
+    var giniImage: String = "gini1"
+
+    func fetchUserData() {
+        userId = manager.getUser().id
+        userFolders = manager.getUser().folders
+        userFoldersMemos = manager.getUser().memos
+        userThemeColor = manager.getUser().themeColor
+
+        userPoint = manager.getUser().rewardPoint
+        userNickName = manager.getUser().nickName // 유저 닉네임
+        rewardNickName = manager.getUser().rewardName // 리워드 닉네임
+
+        if userPoint >= 30 {
+            giniImage = "gini4"
+        } else if userPoint >= 20 {
+            giniImage = "gini3"
+        } else if userPoint >= 10 {
+            giniImage = "gini2"
+        } else {
+            giniImage = "gini1"
+        }
+        
+        print("@@ 유저 패치! user:\(userNickName), giniName: \(rewardNickName), giniImage: \(giniImage)")
+        print("@@ 현재 패치된 유저 정보:", manager.getUser())
     }
-    
-    func updateUserData() {
-//        firebaseManager.updateUserData(email: idLabelText) {
-//            print("업데이트 파이어베이스 유저데이터")
-//        }
+
+    enum EditType {
+        case userNickName
+        case rewardNickName
+    }
+
+    func updateNickName(type: EditType, newName: String) {
+        switch type {
+        case .userNickName:
+            let userWithNewNickName = UserData(id: userId, nickName: newName, folders: userFolders, memos: userFoldersMemos, rewardPoint: userPoint, rewardName: rewardNickName, themeColor: userThemeColor)
+            manager.updateUser(targetId: userId, newUser: userWithNewNickName) {
+                print("@@ 유저 닉네님 업데이트:", userWithNewNickName.nickName)
+            }
+
+        case .rewardNickName:
+            let rewardWithNewNickName = UserData(id: userId, nickName: userNickName, folders: userFolders, memos: userFoldersMemos, rewardPoint: userPoint, rewardName: newName, themeColor: userThemeColor)
+            manager.updateUser(targetId: userId, newUser: rewardWithNewNickName) {
+                print("@@ 리워드 닉네임 업데이트:", rewardWithNewNickName.rewardName)
+            }
+        }
     }
 }

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/SettingPageScene/SettingPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/SettingPageScene/SettingPageViewController.swift
@@ -2,17 +2,15 @@ import SnapKit
 import UIKit
 
 class SettingPageViewController: UIViewController {
-    // 접근 제어(open>public>internal(default)>File-private>private), 특정 코드의 세부구현 감추고 필요한 만큼만 공개해서 정보 보호
-    // private: 선언된 중괄호{} 내부에서만 사용 가능
+
     private let tableView: UITableView = {
-        // tableView style 설정 1) plain 2) grouped 3) insetGrouped
+       
         let table = UITableView(frame: .zero, style: .insetGrouped)
         return table
     }()
 
-    // ☑️ 코드리뷰 제안1: 이중배열로 변경하는 것이 더 좋을 듯! + SettingDataManager 만들어서 데이터모델 분리 필요!
-    var settingOptionData: [[SettingOption]] = [] // 이중배열로 섹션과 열에 들어갈 데이터 표시 후 빈 배열 처리
-    let settingOptionManager = SettingOptionManager() // 데이터매니저 인스턴스 생성
+    var settingOptionData: [[SettingOption]] = []
+    let settingOptionManager = SettingOptionManager()
 }
 
 extension SettingPageViewController {
@@ -22,6 +20,11 @@ extension SettingPageViewController {
         super.viewDidLoad()
         setUp()
         setUpTableView()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(true)
+        tabBarController?.tabBar.isHidden = false
     }
 }
 
@@ -96,19 +99,28 @@ extension SettingPageViewController: UITableViewDelegate, UITableViewDataSource 
         if indexPath.section == 0 && indexPath.row == 0 {
             // 알림 화면으로 이동
             navigationController?.pushViewController(notifyVC, animated: true) // 성준
+            tabBarController?.tabBar.isHidden = true
+
         } else if indexPath.section == 0 && indexPath.row == 1 {
-            // 테마컬러 화면으로 이동 ☑️
+            // 테마컬러 화면으로 이동
             navigationController?.pushViewController(themeColorVC, animated: true)
+            tabBarController?.tabBar.isHidden = true
+
         } else if indexPath.section == 0 && indexPath.row == 2 {
             // 잠금화면으로 이동
             let lockVC = LockSettingViewController()
             navigationController?.pushViewController(lockVC, animated: true)
+            tabBarController?.tabBar.isHidden = true
+
         } else if indexPath.section == 1 && indexPath.row == 0 {
-            // 프로필 화면으로 이동 ☑️
+            // 프로필 화면으로 이동
             navigationController?.pushViewController(profileVC, animated: true)
+            tabBarController?.tabBar.isHidden = true
+            
         } else if indexPath.section == 1 && indexPath.row == 1 {
-            // 로그인 화면으로 이동 ☑️
-            navigationController?.pushViewController(singInVC, animated: true)
+            // 로그아웃 버튼 - 로그인 화면으로 이동
+            let signInVC = SignInPageViewController()
+            (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVC(viewController: signInVC, animated: true)
         }
     }
 }

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/SettingPageScene/SettingPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/SettingPageScene/SettingPageViewController.swift
@@ -2,9 +2,7 @@ import SnapKit
 import UIKit
 
 class SettingPageViewController: UIViewController {
-
     private let tableView: UITableView = {
-       
         let table = UITableView(frame: .zero, style: .insetGrouped)
         return table
     }()
@@ -35,7 +33,6 @@ private extension SettingPageViewController {
         view.addSubview(tableView)
         settingOptionManager.makeSettingOptions() // 데이터 만들기
         settingOptionData = settingOptionManager.getSettingOptions() // 데이터매니저에서 데이터 받아오기!
-        print("settingOptionData: \(settingOptionData)")
     }
 
     func setUpTableView() {
@@ -50,38 +47,29 @@ private extension SettingPageViewController {
 
 extension SettingPageViewController: UITableViewDelegate, UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        print(#function)
         return settingOptionData.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        print(#function)
         if section == 0 {
-            print("section[0] number: \(settingOptionData[0].count)")
             return settingOptionData[0].count
         } else if section == 1 {
-            print("section[1] number: \(settingOptionData[1].count)")
             return settingOptionData[1].count
         }
         return 0
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        print(#function)
         let cell = tableView.dequeueReusableCell(withIdentifier: SettingCell.identifier, for: indexPath) as! SettingCell
         if indexPath.section == 0 {
             let model = settingOptionData[0][indexPath.row]
-            print("model[0]: \(model)")
             cell.configure(with: model)
         } else if indexPath.section == 1 {
             let model = settingOptionData[1][indexPath.row]
-            print("model[1]: \(model)")
             cell.configure(with: model)
         }
 
         cell.backgroundColor = ColorManager.themeArray[0].pointColor02
-
-        // 셀 악세사리타입 설정
         cell.accessoryType = .disclosureIndicator
 
         return cell
@@ -116,7 +104,7 @@ extension SettingPageViewController: UITableViewDelegate, UITableViewDataSource 
             // 프로필 화면으로 이동
             navigationController?.pushViewController(profileVC, animated: true)
             tabBarController?.tabBar.isHidden = true
-            
+
         } else if indexPath.section == 1 && indexPath.row == 1 {
             // 로그아웃 버튼 - 로그인 화면으로 이동
             let signInVC = SignInPageViewController()


### PR DESCRIPTION
- 설정페이지에 속한 내부 페이지 이동 시 탭바 숨기기 및 설정페이지로 되돌아왔을 때 탭바 되살리기


```swift
// 프로필 화면으로 이동 시 탭바 끄기
        navigationController?.pushViewController(profileVC, animated: true)
        tabBarController?.tabBar.isHidden = true

// 뷰컨트롤러가 화면에 나타나기 직전 실행
 override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(true)
        tabBarController?.tabBar.isHidden = false
    }
```

- '로그인뷰에서 탭바' 또는 '로그아웃/계정삭제 버튼으로 로그인뷰' 이동 시 루트뷰 변경
 (SceneDelegate에 extension으로 구현해 주신 changeRootVC 메서드 사용하였습니다.

```swift
// SceneDelegate.swift
  func changeRootVC(viewController: UIViewController, animated: Bool) {
        guard let window = window else { return }
        window.rootViewController = viewController
        UIView.transition(with: window, duration: 0.5, options: [.transitionCrossDissolve], animations: nil, completion: nil)
    }

// SettingPageViewController.swift
let signInVC = SignInPageViewController()
        (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVC(viewController: signInVC, animated: true)
```

#98 