### PR TITLE
Feat/login feature

### DIFF
--- a/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
+++ b/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		08A4F88A2AD8216A0092C6EF /* MemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4F8892AD8216A0092C6EF /* MemoViewController.swift */; };
 		08A4F88C2AD8218E0092C6EF /* MemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4F88B2AD8218E0092C6EF /* MemoView.swift */; };
 		08A4F88E2AD821A80092C6EF /* MemoOptionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4F88D2AD821A80092C6EF /* MemoOptionCollectionViewCell.swift */; };
+		08ACC7382AEF81FB00F4AA9A /* SignInPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACC7372AEF81FB00F4AA9A /* SignInPageViewModel.swift */; };
 		08E7243E2ADE6E840015514D /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 08E7243D2ADE6E840015514D /* FirebaseAnalytics */; };
 		08E724402ADE6E840015514D /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 08E7243F2ADE6E840015514D /* FirebaseAnalyticsOnDeviceConversion */; };
 		08E724422ADE6E840015514D /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 08E724412ADE6E840015514D /* FirebaseAnalyticsSwift */; };
@@ -168,6 +169,7 @@
 		08A4F8892AD8216A0092C6EF /* MemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoViewController.swift; sourceTree = "<group>"; };
 		08A4F88B2AD8218E0092C6EF /* MemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoView.swift; sourceTree = "<group>"; };
 		08A4F88D2AD821A80092C6EF /* MemoOptionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoOptionCollectionViewCell.swift; sourceTree = "<group>"; };
+		08ACC7372AEF81FB00F4AA9A /* SignInPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPageViewModel.swift; sourceTree = "<group>"; };
 		08EB09302AD571CC00CCD51A /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		08F8F47F2ADE5FFF0067D3E4 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		301B39672AE134C200B19313 /* UserDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = UserDataModel.xcdatamodel; sourceTree = "<group>"; };
@@ -386,6 +388,7 @@
 			isa = PBXGroup;
 			children = (
 				084412162AD569E9005F2FA9 /* SignInPageViewController.swift */,
+				08ACC7372AEF81FB00F4AA9A /* SignInPageViewModel.swift */,
 			);
 			path = SginInScene;
 			sourceTree = "<group>";
@@ -778,6 +781,7 @@
 				083C98692AD8DED1006895D2 /* AddMemoPageViewModel.swift in Sources */,
 				084412132AD569C0005F2FA9 /* RewardPageViewController.swift in Sources */,
 				08487F912AE54A39009AE6CB /* LockSettingViewController.swift in Sources */,
+				08ACC7382AEF81FB00F4AA9A /* SignInPageViewModel.swift in Sources */,
 				084412172AD569E9005F2FA9 /* SignInPageViewController.swift in Sources */,
 				081383912AE004620055FDA2 /* LockScreenViewController.swift in Sources */,
 				30E798492AD6362D00903272 /* Extensions.swift in Sources */,

--- a/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
+++ b/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
@@ -536,7 +536,6 @@
 		08F8AE812AE294DF00F79FD0 /* SettingScene */ = {
 			isa = PBXGroup;
 			children = (
-				30E798502AD7F4B900903272 /* ThemeColorPageScene */,
 				084412222AD56BB8005F2FA9 /* SettingPageScene */,
 				30E798532AD7F54C00903272 /* ProfilePageScene */,
 				C735C0422AD8E0EA00AA7663 /* NotifyScene */,
@@ -570,13 +569,6 @@
 				08F8AE7F2AE2897700F79FD0 /* Managers */,
 			);
 			path = Model;
-			sourceTree = "<group>";
-		};
-		30E798502AD7F4B900903272 /* ThemeColorPageScene */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = ThemeColorPageScene;
 			sourceTree = "<group>";
 		};
 		30E798532AD7F54C00903272 /* ProfilePageScene */ = {

--- a/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
+++ b/FinalTodo/FinalTodo.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		08A4F88C2AD8218E0092C6EF /* MemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4F88B2AD8218E0092C6EF /* MemoView.swift */; };
 		08A4F88E2AD821A80092C6EF /* MemoOptionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4F88D2AD821A80092C6EF /* MemoOptionCollectionViewCell.swift */; };
 		08ACC7382AEF81FB00F4AA9A /* SignInPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACC7372AEF81FB00F4AA9A /* SignInPageViewModel.swift */; };
+		08D1BF7A2AF0D40E00FE896A /* SignUpPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08D1BF792AF0D40E00FE896A /* SignUpPageViewModel.swift */; };
 		08E7243E2ADE6E840015514D /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 08E7243D2ADE6E840015514D /* FirebaseAnalytics */; };
 		08E724402ADE6E840015514D /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 08E7243F2ADE6E840015514D /* FirebaseAnalyticsOnDeviceConversion */; };
 		08E724422ADE6E840015514D /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 08E724412ADE6E840015514D /* FirebaseAnalyticsSwift */; };
@@ -170,6 +171,7 @@
 		08A4F88B2AD8218E0092C6EF /* MemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoView.swift; sourceTree = "<group>"; };
 		08A4F88D2AD821A80092C6EF /* MemoOptionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoOptionCollectionViewCell.swift; sourceTree = "<group>"; };
 		08ACC7372AEF81FB00F4AA9A /* SignInPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPageViewModel.swift; sourceTree = "<group>"; };
+		08D1BF792AF0D40E00FE896A /* SignUpPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpPageViewModel.swift; sourceTree = "<group>"; };
 		08EB09302AD571CC00CCD51A /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		08F8F47F2ADE5FFF0067D3E4 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		301B39672AE134C200B19313 /* UserDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = UserDataModel.xcdatamodel; sourceTree = "<group>"; };
@@ -397,6 +399,7 @@
 			isa = PBXGroup;
 			children = (
 				084412182AD569F4005F2FA9 /* SignUpPageViewController.swift */,
+				08D1BF792AF0D40E00FE896A /* SignUpPageViewModel.swift */,
 			);
 			path = SignUpScene;
 			sourceTree = "<group>";
@@ -770,6 +773,7 @@
 				08A4F88E2AD821A80092C6EF /* MemoOptionCollectionViewCell.swift in Sources */,
 				C75C10792AD8274200F70A7D /* DdayPageViewController.swift in Sources */,
 				69EBADD42AEA4E320009CB21 /* FirebaseDBManager.swift in Sources */,
+				08D1BF7A2AF0D40E00FE896A /* SignUpPageViewModel.swift in Sources */,
 				08A4F88A2AD8216A0092C6EF /* MemoViewController.swift in Sources */,
 				0872CD942AE0B46100ABE980 /* LockScreenPasswordCollectionViewCell.swift in Sources */,
 				C735C0462AD8E16D00AA7663 /* AddNotifyPageViewController.swift in Sources */,

--- a/FinalTodo/FinalTodo/Model/Managers/LoginManager.swift
+++ b/FinalTodo/FinalTodo/Model/Managers/LoginManager.swift
@@ -19,7 +19,7 @@ struct LoginResult {
 
 struct LoginManager {
     
-    func trySignUp(email:String, password: String, completion: @escaping (LoginResult) -> Void) {
+    func trySignUp(email:String, password: String, nickName: String, completion: @escaping (LoginResult) -> Void) {
         Auth.auth().createUser(withEmail: email, password: password) { authResult, error in
             var result = LoginResult(isSuccess: true, email: email)
             if error == nil {
@@ -27,6 +27,21 @@ struct LoginManager {
             } else {
                 result.isSuccess = false
                 result.errorMessage = String(describing: error)
+                let user = UserData(
+                    id: email,
+                    nickName: nickName,
+                    folders: [],
+                    memos: [],
+                    rewardPoint: 0,
+                    rewardName: "",
+                    themeColor: "error")
+                FirebaseDBManager.shared.createUser(user: user) { error in
+                    if error == nil {
+                        print("@@@ create Fail")
+                    } else {
+                        print("@@@ create")
+                    }
+                }
                 completion(result)
             }
         }
@@ -45,7 +60,33 @@ struct LoginManager {
         }
     }
     
-    func test(email: String) -> Bool {
-        return Auth.auth().isSignIn(withEmailLink: email)
+    func isAvailableEmail(email: String, completion: @escaping (Bool) -> Void){
+        
+        let db = Firestore.firestore()
+        let users = "users"
+        
+        
+        db.collection(users).getDocuments { data, error in
+            if error != nil {
+                print("[FirebaseManager][\(#function)]: \(String(describing: error?.localizedDescription))")
+            } else {
+                guard let safeData = data else { return }
+                if safeData.documents.map({$0.documentID}).contains(email) {
+                    completion(false)
+                } else {
+                    completion(true)
+                }
+            }
+        }
+    }
+    
+    func passwordFind(email: String) {
+        Auth.auth().sendPasswordReset(withEmail: email) { error in
+            if error == nil {
+                print("send Email")
+            } else {
+                print("fail Email")
+            }
+        }
     }
 }

--- a/FinalTodo/FinalTodo/Model/Managers/LoginManager.swift
+++ b/FinalTodo/FinalTodo/Model/Managers/LoginManager.swift
@@ -23,10 +23,6 @@ struct LoginManager {
         Auth.auth().createUser(withEmail: email, password: password) { authResult, error in
             var result = LoginResult(isSuccess: true, email: email)
             if error == nil {
-                completion(result)
-            } else {
-                result.isSuccess = false
-                result.errorMessage = String(describing: error)
                 let user = UserData(
                     id: email,
                     nickName: nickName,
@@ -34,7 +30,8 @@ struct LoginManager {
                     memos: [],
                     rewardPoint: 0,
                     rewardName: "",
-                    themeColor: "error")
+                    themeColor: "error"
+                )
                 FirebaseDBManager.shared.createUser(user: user) { error in
                     if error == nil {
                         print("@@@ create Fail")
@@ -42,6 +39,10 @@ struct LoginManager {
                         print("@@@ create")
                     }
                 }
+                completion(result)
+            } else {
+                result.isSuccess = false
+                result.errorMessage = String(describing: error)
                 completion(result)
             }
         }

--- a/FinalTodo/FinalTodo/Model/Managers/LoginManager.swift
+++ b/FinalTodo/FinalTodo/Model/Managers/LoginManager.swift
@@ -45,35 +45,7 @@ struct LoginManager {
         }
     }
     
-//     MARK: - Enum 을 이용한 type지정 메서드 구현
-//     함수의 이름으로 정확히 구분하는 것이 좋아서 위의 구분된 함수 사용!
-//
-//    enum SignType {
-//        case signUp
-//        case signIn
-//    }
-//    
-//    func trySign(type: SignType, email: String, password: String, completion: @escaping (LoginResult) -> Void) {
-//        switch type {
-//        case .signIn:
-//            Auth.auth().signIn(withEmail: email, password: password) { authResult, error in
-//                checkError(email: email, authResult: authResult, error: error, completion: completion)
-//            }
-//        case .signUp:
-//            Auth.auth().createUser(withEmail: email, password: password) { authResult, error in
-//                checkError(email: email, authResult: authResult, error: error, completion: completion)
-//            }
-//        }
-//    }
-//    
-//    func checkError(email: String, authResult: AuthDataResult?, error: Error?, completion: @escaping (LoginResult) -> Void) {
-//        var result = LoginResult(isSuccess: true, email: email)
-//        if error == nil {
-//            completion(result)
-//        } else {
-//            result.isSuccess = false
-//            result.errorMessage = String(describing: error)
-//            completion(result)
-//        }
-//    }
+    func test(email: String) -> Bool {
+        return Auth.auth().isSignIn(withEmailLink: email)
+    }
 }

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SginInScene/SignInPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SginInScene/SignInPageViewController.swift
@@ -29,7 +29,7 @@ class SignInPageViewController: UIViewController, CommandLabelDelegate {
     let loginButton = ButtonTappedView(title: "로그인")
     let haveAccountButton = ButtonTappedView(title: "가입이 필요하신가요?")
 
-//    private let viewModel = SignInPageViewModel()
+    private let viewModel = SignInPageViewModel()
 }
 
 extension SignInPageViewController {
@@ -132,19 +132,19 @@ extension SignInPageViewController {
 
 extension SignInPageViewController: ButtonTappedViewDelegate {
     func didTapButton(button: UIButton) {
-//        guard let email = loginBar.inputTextField.text else { return }
-//        guard let password = passwordBar.inputTextField.text else { return }
-//        viewModel.loginManager.trySignIn(email: email, password: password) { loginResult in
-//            if loginResult.isSuccess {
-//                let rootView = TabBarController()
-//                (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVC(viewController: rootView, animated: false)
-//            } else {
-//                print("LoginFail")
-//            }
-//        }
+        guard let email = loginBar.inputTextField.text else { return }
+        guard let password = passwordBar.inputTextField.text else { return }
+        viewModel.loginManager.trySignIn(email: email, password: password) { loginResult in
+            if loginResult.isSuccess {
+                let rootView = TabBarController()
+                (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVC(viewController: rootView, animated: false)
+            } else {
+                print("LoginFail")
+            }
+        }
 
-        // 서령: 로그인 버튼 클릭 시 씬델리게이트의 루트뷰 컨트롤러 탭바로 변경
-        let tabbar = TabBarController()
-        (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVC(viewController: tabbar, animated: true)
+//        // 서령: 로그인 버튼 클릭 시 씬델리게이트의 루트뷰 컨트롤러 탭바로 변경
+//        let tabbar = TabBarController()
+//        (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVC(viewController: tabbar, animated: true)
     }
 }

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SginInScene/SignInPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SginInScene/SignInPageViewController.swift
@@ -40,6 +40,8 @@ class SignInPageViewController: UIViewController, CommandLabelDelegate {
     let haveAccountButton = ButtonTappedView(title: "가입이 필요하신가요?")
 
     private let viewModel = SignInPageViewModel()
+    
+    private let coredataManager = CoreDataManager.shared
 }
 
 extension SignInPageViewController {

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SginInScene/SignInPageViewModel.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SginInScene/SignInPageViewModel.swift
@@ -2,7 +2,7 @@
 //  SignInPageViewModel.swift
 //  FinalTodo
 //
-//  Created by SeoJunYoung on 10/24/23.
+//  Created by SeoJunYoung on 10/30/23.
 //
 
 import Foundation

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SginInScene/SignInPageViewModel.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SginInScene/SignInPageViewModel.swift
@@ -9,4 +9,6 @@ import Foundation
 
 class SignInPageViewModel {
     let loginManager = LoginManager()
+    let email: Observable<String> = Observable("")
+    let password: Observable<String> = Observable("")
 }

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewController.swift
@@ -176,6 +176,7 @@ extension SignUpPageViewController {
                     passwordTextField.infoCommandLabel.textColor = .systemBlue
                 }
             }
+            viewModel.checkPassword.value = viewModel.checkPassword.value
             isPossibleSingUp()
         }
         
@@ -273,18 +274,7 @@ extension SignUpPageViewController {
     
     // 가입버튼 누르면 다음화면으로 넘어가는 것 구현
     func didTapButton(button: UIButton) {
-        print("@@@ didtapSingUpButton")
-//        let user = UserData(
-//            id: viewModel.email.value,
-//            nickName: viewModel.nickName.value,
-//            folders: [],
-//            memos: [],
-//            rewardPoint: 0,
-//            rewardName: "",
-//            themeColor: "error")
-        
-        
-        viewModel.loginManager.trySignUp(email: viewModel.email.value, password: viewModel.password.value, nickName: viewModel.password.value) { [weak self] result in
+        viewModel.loginManager.trySignUp(email: viewModel.email.value, password: viewModel.password.value, nickName: viewModel.nickName.value) { [weak self] result in
             guard let self = self else { return }
             if result.isSuccess {
                 print("Create User")

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewController.swift
@@ -105,10 +105,10 @@ extension SignUpPageViewController {
     
     // email 유효성 검사
     func isValidEmail(testStr:String) -> Bool {
-          let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
-          let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
-          return emailTest.evaluate(with: testStr)
-           }
+        let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
+        return emailTest.evaluate(with: testStr)
+    }
 
     // 빈곳 누르면 키보드 내려가는 함수
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -123,20 +123,7 @@ extension SignUpPageViewController {
     
     // 회원가입 버튼 색갈 바뀌는 함수
     @objc func textFieldEditingChanged(_ textField: UITextField) {
-        // 모든 텍스트 필드에 내용이 있는지 확인합니다.
-        guard
-            let id = idTextBar.inputTextField.text, !id.isEmpty,
-            let password = pwTextBar.inputTextField.text, !password.isEmpty,
-            let confirmPw = confirmPwBar.inputTextField.text, !confirmPw.isEmpty
-        else {
-            // 하나라도 비어 있는 경우 버튼을 비활성화합니다.
-//            registerButton.setButtonEnabled(false)
-//            registerButton.backgroundColor = .systemFill
-            return
-        }
         
-        // 모든 텍스트 필드에 내용이 있는 경우 버튼을 활성화합니다.
-        registerButton.setButtonEnabled(true)
-        registerButton.changeButtonColor(color: .secondarySystemFill)
+        
     }
 }

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewController.swift
@@ -44,7 +44,6 @@ class SignUpPageViewController: UIViewController, ButtonTappedViewDelegate, Comm
         self.registerButton.setButtonEnabled(false)
         setUp()
         bind()
-        viewModel.loginManager.passwordFind(email: "ghddns34@gmail.com")
     }
 }
 

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewController.swift
@@ -22,9 +22,10 @@ class SignUpPageViewController: UIViewController, ButtonTappedViewDelegate, Comm
         return label
     }()
 
-    let idTextBar = CommandLabelView(title: "아이디", placeholder: "아이디를 입력하세요", isSecureTextEntry: false)
-    let pwTextBar = CommandLabelView(title: "비밀번호", placeholder: "• • • • • • • •", isSecureTextEntry: true)
-    let confirmPwBar = CommandLabelView(title: "비밀번호 확인", placeholder: "• • • • • • • •", isSecureTextEntry: true)
+    let idTextBar = CommandLabelView(title: "이메일", placeholder: "이메일을 입력해 주세요.", isSecureTextEntry: false)
+    let nicknameTextField = CommandLabelView(title: "닉네임", placeholder: "닉네임을 입력해 주세요.", isSecureTextEntry: false)
+    let pwTextBar = CommandLabelView(title: "비밀번호", placeholder: "패스워드를 입력해 주세요.", isSecureTextEntry: true)
+    let confirmPwBar = CommandLabelView(title: "비밀번호 확인", placeholder: "패스워드를 재입력해 주세요.", isSecureTextEntry: true)
     let registerButton = ButtonTappedView(title: "가입하기")
     
     override func viewDidLoad() {
@@ -58,21 +59,31 @@ private extension SignUpPageViewController {
         
         // 아이디텍스트
         view.addSubview(idTextBar)
+        idTextBar.addInfoLabel()
         idTextBar.snp.makeConstraints { make in
-            make.top.equalTo(registerLabel.snp.bottom).offset(Constant.screenHeight * 0.03)
+            make.top.equalTo(registerLabel.snp.bottom).offset(Constant.screenHeight * 0.02)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
+        }
+        
+        view.addSubview(nicknameTextField)
+        nicknameTextField.addInfoLabel()
+        nicknameTextField.snp.makeConstraints { make in
+            make.top.equalTo(idTextBar.snp.bottom).offset(Constant.screenHeight * 0.02)
+            make.left.right.equalToSuperview().inset(Constant.defaultPadding)
         }
     }
     
     func setUpPasswordName() {
         // 패스워드 텍스트
         view.addSubview(pwTextBar)
+        pwTextBar.addInfoLabel()
         pwTextBar.snp.makeConstraints { make in
-            make.top.equalTo(idTextBar.snp.bottom).offset(Constant.screenHeight * 0.02)
+            make.top.equalTo(nicknameTextField.snp.bottom).offset(Constant.screenHeight * 0.02)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
         }
         
         view.addSubview(confirmPwBar)
+        confirmPwBar.addInfoLabel()
         confirmPwBar.snp.makeConstraints { make in
             make.top.equalTo(pwTextBar.snp.bottom).offset(Constant.screenHeight * 0.02)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
@@ -85,13 +96,19 @@ private extension SignUpPageViewController {
         registerButton.snp.makeConstraints { make in
             make.top.equalTo(confirmPwBar.snp.bottom).offset(Constant.screenHeight * 0.07)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
-            //        make.height.equalTo(Constant.screenHeight * 0.05)
         }
     }
 }
 
 extension SignUpPageViewController {
     // MARK: - Method
+    
+    // email 유효성 검사
+    func isValidEmail(testStr:String) -> Bool {
+          let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+          let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
+          return emailTest.evaluate(with: testStr)
+           }
 
     // 빈곳 누르면 키보드 내려가는 함수
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -113,8 +130,8 @@ extension SignUpPageViewController {
             let confirmPw = confirmPwBar.inputTextField.text, !confirmPw.isEmpty
         else {
             // 하나라도 비어 있는 경우 버튼을 비활성화합니다.
-            registerButton.setButtonEnabled(false)
-            registerButton.backgroundColor = .systemFill
+//            registerButton.setButtonEnabled(false)
+//            registerButton.backgroundColor = .systemFill
             return
         }
         

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewController.swift
@@ -22,21 +22,29 @@ class SignUpPageViewController: UIViewController, ButtonTappedViewDelegate, Comm
         return label
     }()
 
-    let idTextBar = CommandLabelView(title: "이메일", placeholder: "이메일을 입력해 주세요.", isSecureTextEntry: false)
+    let emailTextField = CommandLabelView(title: "이메일", placeholder: "이메일을 입력해 주세요.", isSecureTextEntry: false)
     let nicknameTextField = CommandLabelView(title: "닉네임", placeholder: "닉네임을 입력해 주세요.", isSecureTextEntry: false)
-    let pwTextBar = CommandLabelView(title: "비밀번호", placeholder: "패스워드를 입력해 주세요.", isSecureTextEntry: true)
-    let confirmPwBar = CommandLabelView(title: "비밀번호 확인", placeholder: "패스워드를 재입력해 주세요.", isSecureTextEntry: true)
+    let passwordTextField = CommandLabelView(title: "비밀번호", placeholder: "패스워드를 입력해 주세요.", isSecureTextEntry: true)
+    let checkPasswordTextField = CommandLabelView(title: "비밀번호 확인", placeholder: "패스워드를 재입력해 주세요.", isSecureTextEntry: true)
     let registerButton = ButtonTappedView(title: "가입하기")
+    
+    let viewModel = SignUpPageViewModel()
     
     override func viewDidLoad() {
         // mark
         super.viewDidLoad()
-        view.backgroundColor = .white
-        idTextBar.delegate = self
-        pwTextBar.delegate = self
-        confirmPwBar.delegate = self
+        view.backgroundColor = .systemBackground
+        emailTextField.delegate = self
+        nicknameTextField.delegate = self
+        passwordTextField.delegate = self
+        checkPasswordTextField.delegate = self
         registerButton.delegate = self
+        self.registerButton.changeTitleColor(color: .label)
+        self.registerButton.changeButtonColor(color: .secondarySystemBackground)
+        self.registerButton.setButtonEnabled(false)
         setUp()
+        bind()
+        viewModel.loginManager.passwordFind(email: "ghddns34@gmail.com")
     }
 }
 
@@ -58,9 +66,9 @@ private extension SignUpPageViewController {
         }
         
         // 아이디텍스트
-        view.addSubview(idTextBar)
-        idTextBar.addInfoLabel()
-        idTextBar.snp.makeConstraints { make in
+        view.addSubview(emailTextField)
+        emailTextField.addInfoLabel()
+        emailTextField.snp.makeConstraints { make in
             make.top.equalTo(registerLabel.snp.bottom).offset(Constant.screenHeight * 0.02)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
         }
@@ -68,24 +76,24 @@ private extension SignUpPageViewController {
         view.addSubview(nicknameTextField)
         nicknameTextField.addInfoLabel()
         nicknameTextField.snp.makeConstraints { make in
-            make.top.equalTo(idTextBar.snp.bottom).offset(Constant.screenHeight * 0.02)
+            make.top.equalTo(emailTextField.snp.bottom).offset(Constant.screenHeight * 0.02)
             make.left.right.equalToSuperview().inset(Constant.defaultPadding)
         }
     }
     
     func setUpPasswordName() {
         // 패스워드 텍스트
-        view.addSubview(pwTextBar)
-        pwTextBar.addInfoLabel()
-        pwTextBar.snp.makeConstraints { make in
+        view.addSubview(passwordTextField)
+        passwordTextField.addInfoLabel()
+        passwordTextField.snp.makeConstraints { make in
             make.top.equalTo(nicknameTextField.snp.bottom).offset(Constant.screenHeight * 0.02)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
         }
         
-        view.addSubview(confirmPwBar)
-        confirmPwBar.addInfoLabel()
-        confirmPwBar.snp.makeConstraints { make in
-            make.top.equalTo(pwTextBar.snp.bottom).offset(Constant.screenHeight * 0.02)
+        view.addSubview(checkPasswordTextField)
+        checkPasswordTextField.addInfoLabel()
+        checkPasswordTextField.snp.makeConstraints { make in
+            make.top.equalTo(passwordTextField.snp.bottom).offset(Constant.screenHeight * 0.02)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
         }
     }
@@ -94,7 +102,7 @@ private extension SignUpPageViewController {
         // 버튼
         view.addSubview(registerButton)
         registerButton.snp.makeConstraints { make in
-            make.top.equalTo(confirmPwBar.snp.bottom).offset(Constant.screenHeight * 0.07)
+            make.top.equalTo(checkPasswordTextField.snp.bottom).offset(Constant.screenHeight * 0.07)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
         }
     }
@@ -103,11 +111,159 @@ private extension SignUpPageViewController {
 extension SignUpPageViewController {
     // MARK: - Method
     
+    func bind() {
+        
+        viewModel.email.bind { [weak self] email in
+            guard let self = self else { return }
+            if email == "" {
+                emailTextField.infoCommandLabel.text = ""
+            } else {
+                if isValidEmail(email: email){
+                    emailTextField.infoCommandLabel.text = "사용 가능여부 조회중"
+                    emailTextField.infoCommandLabel.textColor = .systemGray
+                    viewModel.loginManager.isAvailableEmail(email: email) { result in
+                        if result {
+                            self.emailTextField.infoCommandLabel.text = "사용가능한 이메일 입니다."
+                            self.emailTextField.infoCommandLabel.textColor = .systemBlue
+                        } else {
+                            self.emailTextField.infoCommandLabel.text = "이미 사용중인 이메일 입니다."
+                            self.emailTextField.infoCommandLabel.textColor = .systemRed
+                        }
+                        self.isPossibleSingUp()
+                    }
+                    
+                } else {
+                    emailTextField.infoCommandLabel.text = "이메일 주소를 정확히 입력해주세요."
+                    emailTextField.infoCommandLabel.textColor = .systemRed
+                }
+            }
+            isPossibleSingUp()
+        }
+        
+        viewModel.nickName.bind { [weak self] nickName in
+            guard let self = self else { return }
+            if nickName == "" {
+                nicknameTextField.infoCommandLabel.text = ""
+            } else {
+                if isValidNickName(nickName: nickName){
+                    nicknameTextField.infoCommandLabel.text = "사용가능한 닉네임 입니다."
+                    nicknameTextField.infoCommandLabel.textColor = .systemBlue
+                } else {
+                    nicknameTextField.infoCommandLabel.text = "2글자에서 8글자 사이의 닉네임을 입력해주세요."
+                    nicknameTextField.infoCommandLabel.textColor = .systemRed
+                }
+            }
+            isPossibleSingUp()
+        }
+        
+        viewModel.password.bind { [weak self] password in
+            guard let self = self else { return }
+            if password == "" {
+                passwordTextField.infoCommandLabel.text = ""
+            } else {
+                switch isValidPassword(password: password) {
+                case .length:
+                    passwordTextField.infoCommandLabel.text = "8글자에서 20자 사이의 비밀번호를 입력해주세요."
+                    passwordTextField.infoCommandLabel.textColor = .systemRed
+                case .combination:
+                    passwordTextField.infoCommandLabel.text = "비밀번호는 숫자, 영문, 특수문자를 조합하여야 합니다."
+                    passwordTextField.infoCommandLabel.textColor = .systemRed
+                case .special:
+                    passwordTextField.infoCommandLabel.text = "비밀번호는 특수문자를 포함되어야 합니다."
+                    passwordTextField.infoCommandLabel.textColor = .systemRed
+                case .right:
+                    passwordTextField.infoCommandLabel.text = "사용가능한 비밀번호 입니다."
+                    passwordTextField.infoCommandLabel.textColor = .systemBlue
+                }
+            }
+            isPossibleSingUp()
+        }
+        
+        viewModel.checkPassword.bind { [weak self] password in
+            guard let self = self else { return }
+            if password == "" {
+                checkPasswordTextField.infoCommandLabel.text = ""
+            } else {
+                if password == viewModel.password.value {
+                    checkPasswordTextField.infoCommandLabel.text = "비밀번호가 일치합니다."
+                    checkPasswordTextField.infoCommandLabel.textColor = .systemBlue
+                } else {
+                    checkPasswordTextField.infoCommandLabel.text = "비밀번호가 일치하지 않습니다."
+                    checkPasswordTextField.infoCommandLabel.textColor = .systemRed
+                }
+            }
+            isPossibleSingUp()
+        }
+    }
+    
+    enum PasswordResult {
+        case length
+        case combination
+        case special
+        case right
+    }
+    
     // email 유효성 검사
-    func isValidEmail(testStr:String) -> Bool {
+    func isValidEmail(email: String) -> Bool {
         let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
         let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
-        return emailTest.evaluate(with: testStr)
+        return emailTest.evaluate(with: email)
+    }
+    
+    // nickName 유효성 검사
+    func isValidNickName(nickName: String) -> Bool {
+        return (2...8).contains(nickName.count)
+    }
+    
+    func isValidPassword(password: String) -> PasswordResult {
+        
+        let lengthreg = ".{8,20}"
+        let lengthtesting = NSPredicate(format: "SELF MATCHES %@", lengthreg)
+        if lengthtesting.evaluate(with: password) == false {
+            return .length
+        }
+        let combinationreg = "^(?=.*[A-Za-z])(?=.*[0-9]).{8,20}"
+        let combinationtesting = NSPredicate(format: "SELF MATCHES %@", combinationreg)
+        if combinationtesting.evaluate(with: password) == false {
+            return .combination
+        }
+        let specialreg = "^(?=.*[!@#$%^&*()_+=-]).{8,20}"
+        let specialtesting = NSPredicate(format: "SELF MATCHES %@", specialreg)
+        if specialtesting.evaluate(with: password) == false {
+            return .special
+        }
+        return .right
+    }
+    
+    func isSignUpAble(state: Bool) {
+        UIView.animate(withDuration: 0.3) {
+            if state {
+                self.registerButton.changeTitleColor(color: .systemGray4)
+                self.registerButton.changeButtonColor(color: .secondaryLabel)
+                self.registerButton.setButtonEnabled(true)
+            } else {
+                self.registerButton.changeTitleColor(color: .label)
+                self.registerButton.changeButtonColor(color: .secondarySystemBackground)
+                self.registerButton.setButtonEnabled(false)
+            }
+        }
+    }
+    
+    func isPossibleSingUp() {
+        
+        guard let emailText = emailTextField.infoCommandLabel.text,
+              let nickNameText = nicknameTextField.infoCommandLabel.text,
+              let passwordText = passwordTextField.infoCommandLabel.text,
+              let checkPasswordText = checkPasswordTextField.infoCommandLabel.text else { return }
+
+        if emailText == "사용가능한 이메일 입니다." &&
+            nickNameText == "사용가능한 닉네임 입니다." &&
+            passwordText == "사용가능한 비밀번호 입니다." &&
+            checkPasswordText == "비밀번호가 일치합니다."{
+            isSignUpAble(state: true)
+        } else {
+            isSignUpAble(state: false)
+        }
     }
 
     // 빈곳 누르면 키보드 내려가는 함수
@@ -117,13 +273,60 @@ extension SignUpPageViewController {
     
     // 가입버튼 누르면 다음화면으로 넘어가는 것 구현
     func didTapButton(button: UIButton) {
-        let nextViewController = SignInPageViewController()
-        navigationController?.pushViewController(nextViewController, animated: true)
+        print("@@@ didtapSingUpButton")
+//        let user = UserData(
+//            id: viewModel.email.value,
+//            nickName: viewModel.nickName.value,
+//            folders: [],
+//            memos: [],
+//            rewardPoint: 0,
+//            rewardName: "",
+//            themeColor: "error")
+        
+        
+        viewModel.loginManager.trySignUp(email: viewModel.email.value, password: viewModel.password.value, nickName: viewModel.password.value) { [weak self] result in
+            guard let self = self else { return }
+            if result.isSuccess {
+                print("Create User")
+                let alert = UIAlertController(title: "회원가입 완료", message: "확인을 누르면 로그인 화면으로 돌아 갑니다.", preferredStyle: .alert)
+                let yes = UIAlertAction(title: "확인", style: .default) { action in
+                    self.navigationController?.popViewController(animated: true)
+                }
+                alert.addAction(yes)
+                self.present(alert, animated: true)
+            } else {
+                let alert = UIAlertController(title: "회원가입 실패", message: result.errorMessage, preferredStyle: .alert)
+                let yes = UIAlertAction(title: "확인", style: .default) { action in
+                    self.navigationController?.popViewController(animated: true)
+                }
+                alert.addAction(yes)
+                self.present(alert, animated: true)
+            }
+        }
+
+
+
+        
+//        self.navigationController?.popViewController(animated: true)
     }
     
     // 회원가입 버튼 색갈 바뀌는 함수
     @objc func textFieldEditingChanged(_ textField: UITextField) {
         
+        guard let text = textField.text else { return }
+        
+        switch textField {
+        case emailTextField.inputTextField:
+            viewModel.email.value = text
+        case nicknameTextField.inputTextField:
+            viewModel.nickName.value = text
+        case passwordTextField.inputTextField:
+            viewModel.password.value = text
+        case checkPasswordTextField.inputTextField:
+            viewModel.checkPassword.value = text
+        default:
+            print("등록되지 않은 텍스트 필드")
+        }
         
     }
 }

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewModel.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  SignUpPageViewModel.swift
+//  FinalTodo
+//
+//  Created by SeoJunYoung on 10/31/23.
+//
+
+import Foundation
+
+class SignUpPageViewModel {
+    
+    
+}

--- a/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewModel.swift
+++ b/FinalTodo/FinalTodo/Scenes/LoginScene/SignUpScene/SignUpPageViewModel.swift
@@ -9,5 +9,11 @@ import Foundation
 
 class SignUpPageViewModel {
     
+    let loginManager = LoginManager()
+    
+    let email:Observable<String> = Observable("")
+    let nickName:Observable<String> = Observable("")
+    let password:Observable<String> = Observable("")
+    let checkPassword:Observable<String> = Observable("")
     
 }

--- a/FinalTodo/FinalTodo/SharedView/CommandLabelView.swift
+++ b/FinalTodo/FinalTodo/SharedView/CommandLabelView.swift
@@ -18,6 +18,12 @@ class CommandLabelView: UIView {
         return label
     }()
     
+    let infoCommandLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        return label
+    }()
+    
     //입력바(입력받을수있는 공간..)
     lazy var inputTextField : UITextField = {
         var tf = UITextField()
@@ -85,5 +91,15 @@ extension CommandLabelView {
     @objc func textFieldEditingChanged(_ textField: UITextField) {
         // 이 함수를 델리게이트 메서드로 호출
         delegate?.textFieldEditingChanged(textField)
+    }
+}
+
+extension CommandLabelView {
+    func addInfoLabel() {
+        self.addSubview(infoCommandLabel)
+        infoCommandLabel.snp.makeConstraints { make in
+            make.left.equalTo(commandLabel.snp.right).offset(Constant.defaultPadding)
+            make.centerY.equalTo(commandLabel.snp.centerY)
+        }
     }
 }

--- a/FinalTodo/FinalTodo/SharedView/CommandLabelView.swift
+++ b/FinalTodo/FinalTodo/SharedView/CommandLabelView.swift
@@ -22,8 +22,8 @@ class CommandLabelView: UIView {
     lazy var inputTextField : UITextField = {
         var tf = UITextField()
         tf.backgroundColor = .secondarySystemBackground
-        tf.tintColor = .white
-        tf.textColor = .white
+        tf.tintColor = .label
+        tf.textColor = .label
         tf.font = UIFont.preferredFont(forTextStyle: .headline)
         tf.layer.cornerRadius = 5
         tf.autocapitalizationType = .none //자동으로 대문자 만들어주는 옵션
@@ -47,6 +47,7 @@ class CommandLabelView: UIView {
     }
 }
 private extension CommandLabelView {
+    
     func setup(){
         setupLabelName()
         setupTextField()

--- a/FinalTodo/FinalTodo/SharedView/CommandLabelView.swift
+++ b/FinalTodo/FinalTodo/SharedView/CommandLabelView.swift
@@ -20,7 +20,7 @@ class CommandLabelView: UIView {
     
     let infoCommandLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.font = UIFont.preferredFont(forTextStyle: .caption2)
         return label
     }()
     


### PR DESCRIPTION
# Feat/login feature
## 작업 내용
### SignInPage 기능 연결
- 로그인 성공시 tabbar 로 연결
- 로그인 실패시 UIview Shake 메서드 및 실패 라벨 표기
### SignUpPage 기능 연결
- SingUp하는 순간 Auth.auth().createUser(withEmail: email, password: password)의 컴플리션 핸들러에서 FirebaseDBManager.shared.createUser 생성 
- email 유효성 검사
- nickname 유효성 검사
- password 유효성 검사
- checkPassword 유효성 검사
- 모든 검사 통과시 회원가입 활성화