### PR TITLE
[FIX] 세팅페이지 및 하위페이지 UI 수정

### DIFF
--- a/FinalTodo/FinalTodo/Scenes/RewardPageScene/ColorUIViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/RewardPageScene/ColorUIViewController.swift
@@ -9,79 +9,33 @@ import SnapKit
 import UIKit
 
 class ColorUIViewController: UIViewController, UIColorPickerViewControllerDelegate {
-    lazy var theme1View: UIView = {
-        let view = UIView()
-        view.backgroundColor = UIColor(hex: coredataManager.getUser().themeColor)
-        
-        view.layer.cornerRadius = 10
-        view.layer.borderWidth = 10
-        view.layer.borderColor = UIColor.systemGray.cgColor
-        return view
-    }()
-    
-    private let theme2View: UIView = {
-        let view = UIView()
-        view.backgroundColor = .secondarySystemFill
-        view.layer.cornerRadius = 10
-        view.layer.borderWidth = 10
-        view.layer.borderColor = UIColor.tertiarySystemFill.cgColor
-        return view
-    }()
-    
-    private let themeColorLabel: UILabel = {
-        let label = UILabel()
-        label.text = "테마 컬러"
-        label.font = UIFont.preferredFont(forTextStyle: .title1)
-        return label
-    }()
-    
-    private let firstColorLabel: UILabel = {
-        let label = UILabel()
-        label.text = "컬러 1"
-        label.font = UIFont.preferredFont(forTextStyle: .headline)
-        return label
-    }()
-    
-    private let secondColorLabel: UILabel = {
-        let label = UILabel()
-        label.text = "컬러 2"
-        label.font = UIFont.preferredFont(forTextStyle: .headline)
-        return label
-    }()
-    
-    private let firstColorChangeButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("첫번째 컬러", for: .normal)
-        button.setTitleColor(.white, for: .normal)
-        button.backgroundColor = .gray
-        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .headline)
-        button.layer.cornerRadius = 10
-        button.addTarget(self, action: #selector(showFirstColorPicker), for: .touchUpInside)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
+    private let manager = CoreDataManager.shared
+    lazy var user = manager.getUser()
+
+    private let tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .insetGrouped)
+        return table
     }()
 
-    private let secondColorChangeButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("두번째 컬러", for: .normal)
-        button.setTitleColor(.white, for: .normal)
-        button.backgroundColor = .gray
-        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .headline)
-        button.layer.cornerRadius = 10
-        button.addTarget(self, action: #selector(showSecondColorPicker), for: .touchUpInside)
+    var settingOptionData: [[SettingOption]] = [
+        [SettingOption(icon: "paintpalette", title: "기본컬러", showSwitch: true, isOn: false),
+         SettingOption(icon: "paintpalette.fill", title: "테마컬러 설정", showSwitch: false, isOn: false)],
+        [SettingOption(icon: "moon.stars", title: "다크모드", showSwitch: true, isOn: false)]
+    ]
 
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
-    
-    private let coredataManager = CoreDataManager.shared
-    
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
-
         setUp()
-        setupColorPicker()
+        setUpTableView()
+        setUpColorPicker()
+
+        print("@@", manager.getUser())
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(true)
+        tableView.reloadData()
+        user = manager.getUser()
     }
 }
 
@@ -89,115 +43,48 @@ private extension ColorUIViewController {
     // MARK: - SetUp
 
     func setUp() {
-        setUptheme1()
-//            setUptheme2()
+        navigationItem.title = "테마컬러"
+        view.backgroundColor = .systemBackground
+        view.addSubview(tableView)
     }
-        
-    func setUptheme1() {
-        view.addSubview(themeColorLabel)
-        themeColorLabel.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).inset(Constant.screenHeight * 0.03)
-            make.leading.equalTo(Constant.defaultPadding)
-        }
-            
-        view.addSubview(firstColorLabel)
-        firstColorLabel.snp.makeConstraints { make in
-            make.top.equalTo(themeColorLabel.snp.bottom).offset(Constant.screenHeight * 0.07)
-            make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
-        }
-            
-        view.addSubview(theme1View)
-        theme1View.snp.makeConstraints { make in
-            make.top.equalTo(firstColorLabel.snp.bottom).offset(Constant.screenHeight * 0.05)
-            make.centerX.equalToSuperview()
-               
-            make.height.equalTo(Constant.screenHeight * 0.1)
-            make.width.equalTo(Constant.screenHeight * 0.1)
-        }
-            
-        view.addSubview(firstColorChangeButton)
-        firstColorChangeButton.snp.makeConstraints { make in
-            make.top.equalTo(theme1View.snp.bottom).offset(Constant.screenHeight * 0.01)
-            make.centerX.equalToSuperview()
-        }
+
+    func setUpTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.frame = view.bounds
+        tableView.register(SettingCell.self, forCellReuseIdentifier: SettingCell.identifier)
+        tableView.backgroundColor = .systemBackground
+        tableView.rowHeight = Constant.screenWidth / 10
     }
-        
-//        func setUptheme2() {
-//
-//            view.addSubview(secondColorLabel)
-//            secondColorLabel.snp.makeConstraints { make in
-//                make.top.equalTo(theme1View.snp.bottom).offset(Constant.screenHeight * 0.1)
-//                make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
-//            }
-//            view.addSubview(theme2View)
-//            theme2View.snp.makeConstraints { make in
-//                make.top.equalTo(secondColorLabel.snp.bottom).offset(Constant.screenHeight * 0.05)
-//                make.centerX.equalToSuperview()
-//                make.height.equalTo(Constant.screenHeight * 0.1)
-//                make.width.equalTo(Constant.screenHeight * 0.1)
-//            }
-//
-//            view.addSubview(secondColorChangeButton)
-//            secondColorChangeButton.snp.makeConstraints { make in
-//                make.top.equalTo(theme2View.snp.bottom).offset(Constant.screenHeight * 0.01)
-//                make.centerX.equalToSuperview()
-//            }
-//        }
 }
 
 extension ColorUIViewController {
-    // 컬러 피커를 설정하는 함수
-    private func setupColorPicker() {
+    private func setUpColorPicker() {
         let colorPicker = UIColorPickerViewController()
         colorPicker.delegate = self
         colorPicker.supportsAlpha = true
         colorPicker.modalPresentationStyle = .popover
-        colorPicker.popoverPresentationController?.sourceView = firstColorChangeButton
-        colorPicker.popoverPresentationController?.sourceView = secondColorChangeButton
-        // 뷰 컨트롤러에 컬러 피커를 추가합니다.
+
         addChild(colorPicker)
     }
 
-    @objc private func showFirstColorPicker() {
+    private func showColorPicker() {
         let picker = UIColorPickerViewController()
         picker.delegate = self
-        picker.selectedColor = theme1View.backgroundColor ?? .white
+        picker.selectedColor = .myPointColor
         picker.supportsAlpha = true
-        // 첫 번째 컬러 피커를 표시할 때는 첫 번째 버튼의 태그를 설정
-        firstColorChangeButton.tag = 1
-        secondColorChangeButton.tag = 0 // 두 번째 버튼의 태그를 초기화
+
         present(picker, animated: true, completion: nil)
     }
 
-    @objc private func showSecondColorPicker() {
-        let picker = UIColorPickerViewController()
-        picker.delegate = self
-        picker.selectedColor = theme2View.backgroundColor ?? .white
-        picker.supportsAlpha = true
-        // 두 번째 컬러 피커를 표시할 때는 두 번째 버튼의 태그를 설정
-        firstColorChangeButton.tag = 0 // 첫 번째 버튼의 태그를 초기화
-        secondColorChangeButton.tag = 2
-        present(picker, animated: true, completion: nil)
-    }
-
-    // 사용자가 색상을 선택하면 호출되는 델리게이트 메서드
     func showColorPicker(_ sender: Any) {
         let picker = UIColorPickerViewController()
         picker.selectedColor = UIColor.cyan
         picker.supportsAlpha = true
         present(picker, animated: true, completion: nil)
     }
-    
-    func colorPickerViewControllerDidFinish(_ viewController: UIColorPickerViewController) {
-        // 버튼의 태그를 사용하여 어떤 버튼을 클릭했는지 구별
-//        if firstColorChangeButton.tag == 1 {
-//            theme1View.backgroundColor = viewController.selectedColor
-//        } else if secondColorChangeButton.tag == 2 {
-//            theme2View.backgroundColor = viewController.selectedColor
-//        }
 
-        let user = coredataManager.getUser()
-        
+    func colorPickerViewControllerDidFinish(_ viewController: UIColorPickerViewController) {
         if user.id == "error" {
             let alert = UIAlertController(title: "오류", message: "로그인이 필요합니다", preferredStyle: .alert)
             let yes = UIAlertAction(title: "확인", style: .cancel)
@@ -206,13 +93,84 @@ extension ColorUIViewController {
         } else {
             let color = viewController.selectedColor.toHexString()
             let updateUser = UserData(id: user.id, nickName: user.nickName, folders: user.folders, memos: user.memos, rewardPoint: user.rewardPoint, rewardName: user.rewardName, themeColor: color)
-            coredataManager.updateUser(targetId: user.id, newUser: updateUser) {
+            manager.updateUser(targetId: user.id, newUser: updateUser) {
                 print("Update Color")
             }
             UIColor.myPointColor = UIColor(hex: color)
-            theme1View.backgroundColor = UIColor(hex: color)
         }
-        
-        viewController.dismiss(animated: true, completion: nil)
+        viewController.dismiss(animated: true) { [self] in
+            user = manager.getUser()
+            tableView.reloadData()
+        }
+    }
+}
+
+extension ColorUIViewController: UITableViewDelegate, UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return settingOptionData.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section == 0 {
+            return settingOptionData[0].count
+        } else if section == 1 {
+            return settingOptionData[1].count
+        }
+        return 0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SettingCell.identifier, for: indexPath) as! SettingCell
+
+        if indexPath.section == 0 && indexPath.row == 0 {
+            let model = settingOptionData[0][indexPath.row]
+            cell.configure(with: model)
+            cell.accessoryView = .none
+            cell.accessoryType = .none
+
+        } else if indexPath.section == 0 && indexPath.row == 1 {
+            let model = settingOptionData[0][indexPath.row]
+            cell.configure(with: model)
+            cell.accessoryType = .disclosureIndicator
+
+            let colorView: UIView = {
+                let view = UIView()
+                view.backgroundColor = .myPointColor
+                view.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
+                view.layer.cornerRadius = 5
+                return view
+            }()
+            cell.accessoryView = colorView
+
+        } else if indexPath.section == 1 {
+            let model = settingOptionData[1][indexPath.row]
+            cell.configure(with: model)
+            cell.accessoryView = .none
+            cell.accessoryType = .none
+        }
+
+        cell.backgroundColor = .secondarySystemBackground
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        if indexPath.section == 0 && indexPath.row == 0 {
+            // 기본컬러 설정 로직 필요
+            let color = UIColor.secondaryLabel.toHexString()
+            let updateUser = UserData(id: user.id, nickName: user.nickName, folders: user.folders, memos: user.memos, rewardPoint: user.rewardPoint, rewardName: user.rewardName, themeColor: color)
+            manager.updateUser(targetId: user.id, newUser: updateUser) { [self] in
+                user = manager.getUser()
+                tableView.reloadData()
+            }
+
+        } else if indexPath.section == 0 && indexPath.row == 1 {
+            // 테마컬러 설정
+            showColorPicker()
+
+        } else if indexPath.section == 1 && indexPath.row == 0 {
+            // 다크모드 기능 구현 필요
+        }
     }
 }

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/DeleteAccountPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/DeleteAccountPageViewController.swift
@@ -8,6 +8,28 @@
 import UIKit
 
 class DeleteAccountPageViewController: UIViewController {
+    private lazy var giniChatLabel: UILabel = {
+        let label = UILabel()
+        label.text = "정말... 계정 삭제하실 건가요?"
+        label.font = UIFont.preferredFont(forTextStyle: .headline)
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.backgroundColor = .systemFill
+        label.layer.cornerRadius = 10
+        label.layer.masksToBounds = true
+        return label
+    }()
+
+    private lazy var allertLabel: UILabel = {
+        let label = UILabel()
+        label.text = "계정 삭제 시 \n데이터가 모두 삭제되니 주의해 주세요."
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.textColor = .systemGray
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
     private lazy var giniImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(named: "gini1")
@@ -15,30 +37,11 @@ class DeleteAccountPageViewController: UIViewController {
         return imageView
     }()
 
-    private lazy var giniChatLabel: UILabel = {
-        let label = UILabel()
-        label.text = "정말... 계정 삭제하실 건가요?"
-        label.font = UIFont.preferredFont(forTextStyle: .title1)
-        label.textAlignment = .center
-        label.numberOfLines = 0
-        return label
-    }()
-
     private let deleteAccountButton: UIButton = {
         let button = UIButton()
         button.setTitle("계정 삭제", for: .normal)
         button.setTitleColor(.label, for: .normal)
         return button
-    }()
-
-    private lazy var allertLabel: UILabel = {
-        let label = UILabel()
-        label.text = "*주의*\n계정 삭제 시 \n폴더·메모·기니피그 데이터가 함께 삭제됩니다."
-        label.font = UIFont.preferredFont(forTextStyle: .body)
-        label.textColor = .systemGray
-        label.textAlignment = .center
-        label.numberOfLines = 0
-        return label
     }()
 
     override func viewDidLoad() {
@@ -53,7 +56,7 @@ class DeleteAccountPageViewController: UIViewController {
 
 private extension DeleteAccountPageViewController {
     func setUp() {
-        title = "계정 삭제"
+        navigationItem.title = "계정 삭제"
         view.backgroundColor = .systemBackground
 
         deleteAccountButton.addTarget(self, action: #selector(DidTapDeleteAccountButton), for: .touchUpInside)
@@ -65,18 +68,20 @@ private extension DeleteAccountPageViewController {
 
         giniChatLabel.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).inset(Constant.screenHeight * 0.1)
-            make.centerX.equalToSuperview()
-        }
-
-        giniImageView.snp.makeConstraints { make in
-            make.top.equalTo(giniChatLabel.snp.bottom).offset(Constant.defaultPadding)
-            make.height.equalTo(Constant.screenHeight * 0.45)
-            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
+            make.height.equalTo(Constant.screenHeight * 0.08)
         }
 
         allertLabel.snp.makeConstraints { make in
-            make.top.equalTo(giniImageView.snp.bottom).offset(Constant.defaultPadding * 2)
+            make.top.equalTo(giniChatLabel.snp.bottom).offset(Constant.defaultPadding)
             make.leading.trailing.equalToSuperview().inset(Constant.defaultPadding)
+        }
+
+        giniImageView.snp.makeConstraints { make in
+            make.top.equalTo(allertLabel.snp.bottom).offset(Constant.defaultPadding)
+            make.width.equalTo(Constant.screenWidth * 0.4)
+            make.height.equalTo(Constant.screenHeight * 0.3)
+            make.centerX.equalToSuperview()
         }
 
         deleteAccountButton.snp.makeConstraints { make in

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/ProfilePageScene/ProfilePageViewController.swift
@@ -30,11 +30,21 @@ class ProfilePageViewController: UIViewController {
 
     private lazy var rewardImageButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(named: viewModel.giniImage), for: .normal)
         button.layer.borderWidth = 1.5
         button.layer.borderColor = UIColor.systemFill.cgColor
         button.addTarget(self, action: #selector(didTapGiniImageButton), for: .touchUpInside)
         button.backgroundColor = .systemBackground
+
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: viewModel.giniImage)
+        imageView.contentMode = .scaleAspectFit // 이미지를 원래 비율로 유지하도록 설정
+
+        button.addSubview(imageView)
+
+        imageView.snp.makeConstraints { make in
+            make.top.bottom.leading.trailing.equalToSuperview()
+        }
+
         return button
     }()
 
@@ -70,8 +80,7 @@ class ProfilePageViewController: UIViewController {
 
     private let tableView: UITableView = {
         let table = UITableView(frame: .zero, style: .insetGrouped)
-        table.rowHeight = Constant.screenHeight * 0.1
-        table.backgroundColor = .secondarySystemBackground
+        table.backgroundColor = .clear
         return table
     }()
 
@@ -89,9 +98,6 @@ class ProfilePageViewController: UIViewController {
             print("@@viewDidLoad")
         }
         setUp()
-        tableView.dataSource = self
-        tableView.delegate = self
-        tableView.register(SettingCell.self, forCellReuseIdentifier: SettingCell.identifier)
     }
 }
 
@@ -99,6 +105,12 @@ private extension ProfilePageViewController {
     func setUp() {
         title = "프로필"
         view.backgroundColor = .systemBackground
+
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(SettingCell.self, forCellReuseIdentifier: SettingCell.identifier)
+        tableView.rowHeight = Constant.screenWidth / 10
+        tableView.isScrollEnabled = false
 
         view.addSubview(rewardImageButton)
         view.addSubview(chatView)

--- a/FinalTodo/FinalTodo/Scenes/SettingScene/SettingPageScene/SettingPageViewController.swift
+++ b/FinalTodo/FinalTodo/Scenes/SettingScene/SettingPageScene/SettingPageViewController.swift
@@ -29,22 +29,22 @@ extension SettingPageViewController {
 
 private extension SettingPageViewController {
     func setUp() {
-        title = "설정"
+        navigationItem.title = "설정"
         view.backgroundColor = .systemBackground
         view.addSubview(tableView)
-        settingOptionManager.makeSettingOptions() // 데이터 만들기
-        settingOptionData = settingOptionManager.getSettingOptions() // 데이터매니저에서 데이터 받아오기!
-        
-        if let navigationBar = self.navigationController?.navigationBar {
+        settingOptionManager.makeSettingOptions()
+        settingOptionData = settingOptionManager.getSettingOptions()
+
+        if let navigationBar = navigationController?.navigationBar {
             navigationBar.tintColor = .label
         }
     }
 
     func setUpTableView() {
-        tableView.delegate = self // 테이블뷰 동작 구현 대리자로 해당 뷰컨트롤러 설정
-        tableView.dataSource = self // 테이블뷰 구성 구현 대리자로 해당 뷰컨트롤러 설정
-        tableView.frame = view.bounds // 화면을 꽉 채우기 위해 오토레이아웃 대신 설정
-        tableView.register(SettingCell.self, forCellReuseIdentifier: SettingCell.identifier) // 셀 등록 필수
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.frame = view.bounds
+        tableView.register(SettingCell.self, forCellReuseIdentifier: SettingCell.identifier)
         tableView.backgroundColor = .systemBackground
         tableView.rowHeight = Constant.screenWidth / 10
     }
@@ -73,7 +73,7 @@ extension SettingPageViewController: UITableViewDelegate, UITableViewDataSource 
             let model = settingOptionData[1][indexPath.row]
             cell.configure(with: model)
         }
-        
+
         cell.backgroundColor = .secondarySystemBackground
         cell.accessoryType = .disclosureIndicator
 
@@ -81,44 +81,34 @@ extension SettingPageViewController: UITableViewDelegate, UITableViewDataSource 
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true) // 성준 - 셀 선택상태 해제(셀 터치시 한번만 터치되게끔)
-        let notifyVC = NotifyPageViewController() // 성준
+        tableView.deselectRow(at: indexPath, animated: true)
+        let notifyVC = NotifyPageViewController()
         let themeColorVC = ColorUIViewController()
-//        let lockVC = ThemeColorViewController
-
         let profileVC = ProfilePageViewController()
-        let singInVC = SignInPageViewController()
 
         if indexPath.section == 0 && indexPath.row == 0 {
-            // 알림 화면으로 이동
-            navigationController?.pushViewController(notifyVC, animated: true) // 성준
+            navigationController?.pushViewController(notifyVC, animated: true)
             tabBarController?.tabBar.isHidden = true
 
         } else if indexPath.section == 0 && indexPath.row == 1 {
-            // 테마컬러 화면으로 이동
             navigationController?.pushViewController(themeColorVC, animated: true)
             tabBarController?.tabBar.isHidden = true
 
         } else if indexPath.section == 0 && indexPath.row == 2 {
-            // 잠금화면으로 이동
             let lockVC = LockSettingViewController()
             navigationController?.pushViewController(lockVC, animated: true)
             tabBarController?.tabBar.isHidden = true
 
         } else if indexPath.section == 1 && indexPath.row == 0 {
-            // 프로필 화면으로 이동
             navigationController?.pushViewController(profileVC, animated: true)
             tabBarController?.tabBar.isHidden = true
 
         } else if indexPath.section == 1 && indexPath.row == 1 {
-            // 로그아웃 버튼 - 로그인 화면으로 이동
             let signInVC = SignInPageViewController()
             (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootVC(viewController: signInVC, animated: true)
-        }
-        else if indexPath.section == 1 && indexPath.row == 2 {
-            // 로그아웃 버튼 - 로그인 화면으로 이동
+        } else if indexPath.section == 1 && indexPath.row == 2 {
             let vc = AppInfoViewController()
-            self.navigationController?.pushViewController(vc, animated: true)
+            navigationController?.pushViewController(vc, animated: true)
         }
     }
 }

--- a/FinalTodo/FinalTodo/SharedView/Cells/SettingCell.swift
+++ b/FinalTodo/FinalTodo/SharedView/Cells/SettingCell.swift
@@ -4,7 +4,6 @@ import UIKit
 class SettingCell: UITableViewCell {
     weak var delegate: SettingCellDelegate? // 성준 - 델리게이트 프로퍼티 추가
 
-    // 스택뷰: 디폴트값 .horizontal
     private let stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.spacing = Constant.defaultPadding
@@ -14,7 +13,7 @@ class SettingCell: UITableViewCell {
 
     private let iconImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.tintColor = .myPointColor
+        imageView.tintColor = .label
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
@@ -87,7 +86,7 @@ class SettingCell: UITableViewCell {
         cellSwitch.isHidden = !option.showSwitch
         cellSwitch.isOn = option.isOn
         detailLabel.text = option.detailText
-        iconImageView.tintColor = .myPointColor
+        iconImageView.tintColor = .secondaryLabel
     }
 
     // 성준 - 스위치 on / off 시 설정


### PR DESCRIPTION
*설정 & 테마컬러 & 프로필 & 계정삭제

1. 설정 - 셀 아이콘 기본 컬러로 변경 .label ☑️
2. 테마컬러 - 뷰컨트롤러 네비게이션 네임으로 타이틀 이동 ”테마컬러” ☑️
3. 테마컬러 - inset table로 섹션1 [베이직컬러(복귀)] [테마컬러 (컬러피커 팝업)] // 섹션2  [다크모드 ( o)(스위치)] UI 구현☑️ -> 버그 수정 ☑️
4. 프로필 - 프로필 사진 비율 조정 ☑️
5. 프로필 - inset table로 변경 후 스크롤 막기 ☑️
6. 계정삭제 - 이미지 크기 조정 및 UI 수정☑️


![Simulator Screenshot - iPhone 14 Pro - 2023-11-02 at 02 42 27](https://github.com/NBCampFinal5/FinalTodo/assets/139095139/c79f784a-e6e5-487b-8b53-a5e0ea915815)
